### PR TITLE
allow http for local and tailscale tailnet addresses

### DIFF
--- a/src/connection/preflight.ts
+++ b/src/connection/preflight.ts
@@ -35,7 +35,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
     return buildFailure({
       remoteUrl: options.remoteUrl,
       reason: "invalid_url",
-      detail: error instanceof Error ? error.message : "Enter a valid HTTPS URL.",
+      detail: error instanceof Error ? error.message : "Enter a valid remote URL.",
     });
   }
 

--- a/src/connection/preflight.ts
+++ b/src/connection/preflight.ts
@@ -34,6 +34,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
   } catch (error) {
     return buildFailure({
       remoteUrl: options.remoteUrl,
+      insecureTransport: false,
       reason: "invalid_url",
       detail: error instanceof Error ? error.message : "Enter a valid remote URL.",
     });
@@ -48,6 +49,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         remoteUrl: normalized.normalizedUrl,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         reason: "not_paperclip",
         detail: "This host does not appear to expose the Paperclip health endpoint.",
         warning: normalized.warning,
@@ -59,6 +61,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         paperclipDetected: true,
         deploymentMode: health.deploymentMode,
         deploymentExposure: health.deploymentExposure,
@@ -78,6 +81,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         paperclipDetected: true,
         deploymentMode: health.deploymentMode,
         deploymentExposure: health.deploymentExposure,
@@ -98,6 +102,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         paperclipDetected: true,
         deploymentMode: health.deploymentMode,
         deploymentExposure: health.deploymentExposure,
@@ -117,6 +122,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         paperclipDetected: true,
         deploymentMode: health.deploymentMode,
         deploymentExposure: health.deploymentExposure,
@@ -137,6 +143,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
         origin: normalized.origin,
+        insecureTransport: normalized.insecureTransport,
         paperclipDetected: true,
         deploymentMode: health.deploymentMode,
         deploymentExposure: health.deploymentExposure,
@@ -155,6 +162,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
       ok: true,
       normalizedUrl: normalized.normalizedUrl,
       origin: normalized.origin,
+      insecureTransport: normalized.insecureTransport,
       paperclipDetected: true,
       deploymentMode: health.deploymentMode,
       deploymentExposure: health.deploymentExposure,
@@ -170,6 +178,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
       remoteUrl: normalized.normalizedUrl,
       normalizedUrl: normalized.normalizedUrl,
       origin: normalized.origin,
+      insecureTransport: normalized.insecureTransport,
       reason: classifyFetchError(error),
       detail: error instanceof Error ? error.message : "Remote preflight failed.",
       warning: normalized.warning,
@@ -289,6 +298,7 @@ function buildFailure(input: {
   remoteUrl: string;
   normalizedUrl?: string;
   origin?: string;
+  insecureTransport?: boolean;
   reason: RemotePreflightResult["reason"];
   detail: string;
   warning?: string;
@@ -297,6 +307,7 @@ function buildFailure(input: {
     ok: false,
     normalizedUrl: input.normalizedUrl ?? input.remoteUrl.trim(),
     origin: input.origin ?? "",
+    insecureTransport: input.insecureTransport === true,
     paperclipDetected: false,
     deploymentMode: null,
     deploymentExposure: null,

--- a/src/connection/profiles.ts
+++ b/src/connection/profiles.ts
@@ -75,7 +75,9 @@ export class ConnectionStore {
       return LOCAL_PROFILE_ID;
     }
 
-    return this.cache.remoteProfiles.some((profile) => profile.id === state.activeProfileId)
+    return this.cache.remoteProfiles.some((profile) =>
+      profile.id === state.activeProfileId
+      && (!profile.remoteUrl?.startsWith("http://") || profile.allowInsecureHttp === true))
       ? state.activeProfileId
       : null;
   }
@@ -84,10 +86,14 @@ export class ConnectionStore {
     profileId?: string;
     name?: string;
     remoteUrl: string;
+    allowInsecureHttp?: boolean;
     now?: string;
   }): ConnectionProfile {
     const now = input.now ?? new Date().toISOString();
     const normalized = normalizeRemoteUrl(input.remoteUrl);
+    if (normalized.insecureTransport && input.allowInsecureHttp !== true) {
+      throw new Error("HTTP remotes require confirming that you want to allow an insecure connection.");
+    }
     const existingIndex = input.profileId
       ? this.cache.remoteProfiles.findIndex((profile) => profile.id === input.profileId)
       : -1;
@@ -98,6 +104,7 @@ export class ConnectionStore {
         ...existing,
         name: sanitizeProfileName(input.name, normalized.origin),
         remoteUrl: normalized.normalizedUrl,
+        allowInsecureHttp: normalized.insecureTransport ? true : undefined,
         updatedAt: now,
       };
       this.cache.remoteProfiles[existingIndex] = updated;
@@ -110,6 +117,7 @@ export class ConnectionStore {
       name: sanitizeProfileName(input.name, normalized.origin),
       mode: "remote_existing",
       remoteUrl: normalized.normalizedUrl,
+      allowInsecureHttp: normalized.insecureTransport ? true : undefined,
       createdAt: now,
       updatedAt: now,
       lastHealth: "unknown",
@@ -127,6 +135,7 @@ export class ConnectionStore {
       ...existing,
       id: randomUUID(),
       name: `${existing.name} (copy)`,
+      allowInsecureHttp: existing.allowInsecureHttp,
       createdAt: now,
       updatedAt: now,
       lastConnectedAt: undefined,
@@ -183,6 +192,7 @@ export class ConnectionStore {
     profile.updatedAt = now;
     if (result) {
       profile.remoteUrl = result.normalizedUrl;
+      profile.allowInsecureHttp = result.insecureTransport ? true : undefined;
       profile.lastHealth = deriveHealth(result);
       profile.lastDeploymentMode = result.deploymentMode;
       profile.lastSessionState = result.sessionState;
@@ -195,15 +205,22 @@ export class ConnectionStore {
     const profile = this.requireRemoteProfile(profileId);
     profile.updatedAt = now;
     profile.remoteUrl = result.normalizedUrl;
+    profile.allowInsecureHttp = result.insecureTransport ? true : undefined;
     profile.lastHealth = deriveHealth(result);
     profile.lastDeploymentMode = result.deploymentMode;
     profile.lastSessionState = result.sessionState;
     this.persist();
   }
 
-  syncRemoteProfileUrl(profileId: string, normalizedUrl: string, now = new Date().toISOString()): void {
+  syncRemoteProfileUrl(
+    profileId: string,
+    normalizedUrl: string,
+    allowInsecureHttp = false,
+    now = new Date().toISOString(),
+  ): void {
     const profile = this.requireRemoteProfile(profileId);
     profile.remoteUrl = normalizedUrl;
+    profile.allowInsecureHttp = allowInsecureHttp ? true : undefined;
     profile.updatedAt = now;
     this.persist();
   }
@@ -302,6 +319,8 @@ function sanitizeRemoteProfile(raw: unknown): ConnectionProfile | null {
       name: sanitizeProfileName(typeof raw.name === "string" ? raw.name : undefined, normalized.origin),
       mode: "remote_existing",
       remoteUrl: normalized.normalizedUrl,
+      allowInsecureHttp:
+        normalized.insecureTransport && raw.allowInsecureHttp === true ? true : undefined,
       createdAt,
       updatedAt,
       lastConnectedAt: typeof raw.lastConnectedAt === "string" ? raw.lastConnectedAt : undefined,

--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -27,6 +27,7 @@ export interface ConnectionProfile {
   name: string;
   mode: ConnectionMode;
   remoteUrl?: string;
+  allowInsecureHttp?: boolean;
   createdAt: string;
   updatedAt: string;
   lastConnectedAt?: string;
@@ -55,6 +56,7 @@ export interface RemotePreflightResult {
   ok: boolean;
   normalizedUrl: string;
   origin: string;
+  insecureTransport: boolean;
   paperclipDetected: boolean;
   deploymentMode: DeploymentMode | null;
   deploymentExposure: DeploymentExposure | null;

--- a/src/connection/validate.ts
+++ b/src/connection/validate.ts
@@ -2,6 +2,7 @@ export interface NormalizedRemoteUrl {
   input: string;
   normalizedUrl: string;
   origin: string;
+  insecureTransport: boolean;
   warning?: string;
 }
 
@@ -26,10 +27,6 @@ export function normalizeRemoteUrl(input: string): NormalizedRemoteUrl {
     throw new Error("Remote URLs must use HTTP or HTTPS.");
   }
 
-  if (isHttp && !isPrivateHostname(parsed.hostname)) {
-    throw new Error("Remote URLs must use HTTPS unless the host is on a local or private network.");
-  }
-
   if (parsed.username || parsed.password) {
     throw new Error("Remote URLs cannot include username or password.");
   }
@@ -43,11 +40,13 @@ export function normalizeRemoteUrl(input: string): NormalizedRemoteUrl {
     input: trimmed,
     normalizedUrl,
     origin: parsed.origin,
+    insecureTransport: isHttp,
+    warning: isHttp ? buildInsecureHttpWarning(parsed.hostname) : undefined,
   };
 }
 
 export function isPrivateHostname(hostname: string): boolean {
-  const lower = hostname.toLowerCase();
+  const lower = normalizeHostname(hostname);
 
   if (lower === "localhost" || lower === "::1" || lower.endsWith(".localhost")) {
     return true;
@@ -86,6 +85,26 @@ function isPrivateIpv4(hostname: string): boolean {
 }
 
 function isPrivateIpv6(hostname: string): boolean {
-  const lower = hostname.toLowerCase();
+  const lower = normalizeHostname(hostname);
   return lower === "::1" || lower.startsWith("fc") || lower.startsWith("fd");
+}
+
+function normalizeHostname(hostname: string): string {
+  const lower = hostname.toLowerCase();
+  if (lower.startsWith("[") && lower.endsWith("]")) {
+    return lower.slice(1, -1);
+  }
+
+  return lower;
+}
+
+function buildInsecureHttpWarning(hostname: string): string {
+  const baseWarning =
+    "Warning: this remote uses HTTP without TLS. Network traffic can be read or modified by anyone on the path.";
+
+  if (isPrivateHostname(hostname)) {
+    return `${baseWarning} Only continue if you trust the local or private network carrying this connection.`;
+  }
+
+  return `${baseWarning} This host is not on a recognized private network, so the risk is higher.`;
 }

--- a/src/connection/validate.ts
+++ b/src/connection/validate.ts
@@ -10,18 +10,24 @@ const PRIVATE_HOST_SUFFIXES = [".internal", ".local", ".lan", ".home", ".ts.net"
 export function normalizeRemoteUrl(input: string): NormalizedRemoteUrl {
   const trimmed = input.trim();
   if (!trimmed) {
-    throw new Error("Enter a valid HTTPS URL.");
+    throw new Error("Enter a valid remote URL.");
   }
 
   let parsed: URL;
   try {
     parsed = new URL(trimmed);
   } catch {
-    throw new Error("Enter a valid HTTPS URL.");
+    throw new Error("Enter a valid remote URL.");
   }
 
-  if (parsed.protocol !== "https:") {
-    throw new Error("Remote URLs must use HTTPS.");
+  const isHttp = parsed.protocol === "http:";
+  const isHttps = parsed.protocol === "https:";
+  if (!isHttp && !isHttps) {
+    throw new Error("Remote URLs must use HTTP or HTTPS.");
+  }
+
+  if (isHttp && !isPrivateHostname(parsed.hostname)) {
+    throw new Error("Remote URLs must use HTTPS unless the host is on a local or private network.");
   }
 
   if (parsed.username || parsed.password) {

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -341,6 +341,115 @@ export function getLauncherHtml(): string {
   .status-card.warning-card .remember-row label {
     color: inherit;
   }
+
+  .step-panel {
+    width: 340px;
+    border: 1px solid #1f1f22;
+    border-radius: 10px;
+    background: #0d0d10;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+    text-align: left;
+    transition: opacity 0.2s;
+  }
+  .step-panel.muted { opacity: 0.4; pointer-events: none; }
+  .step-panel-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 12px;
+    color: #a1a1aa;
+    margin-bottom: 10px;
+    min-height: 22px;
+  }
+  .step-panel-head.no-body { margin-bottom: 0; }
+  .step-panel-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+  .step-panel .form-group { width: 100%; margin-bottom: 0; }
+  .step-panel .status-card {
+    width: 100%;
+    margin-bottom: 0;
+  }
+  .step-panel #testStatus .status-badge {
+    margin: 0;
+  }
+  .step-placeholder {
+    font-size: 11px;
+    color: #52525b;
+    padding: 2px 0;
+  }
+
+  /* The plain status-card carries no visible UI inside the step panel;
+     its contents live in the #verifyInfo tooltip. */
+  .step-panel .status-card:not(.warning-card) { display: none; }
+
+  /* Info icon in the verify step head (carries the detail text) */
+  .verify-info {
+    position: relative;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #27272a;
+    color: #a1a1aa;
+    font-size: 10px;
+    font-weight: 600;
+    cursor: help;
+    user-select: none;
+    flex-shrink: 0;
+  }
+  .verify-info.visible { display: inline-flex; }
+  .verify-info:hover { background: #3f3f46; color: #e4e4e7; }
+  .verify-info .verify-tooltip {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    right: 0;
+    width: 260px;
+    padding: 10px;
+    background: #0a0a0b;
+    border: 1px solid #3f3f46;
+    border-radius: 6px;
+    color: #d4d4d8;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.4;
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    z-index: 10;
+    white-space: normal;
+  }
+  .verify-tooltip .tip-detail {
+    display: block;
+    margin-bottom: 8px;
+  }
+  .verify-tooltip .tip-meta {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: 10px;
+    row-gap: 3px;
+    font-size: 10px;
+    padding-top: 8px;
+    border-top: 1px solid #27272a;
+  }
+  .verify-tooltip .tip-meta .k { color: #71717a; }
+  .verify-tooltip .tip-meta .v { color: #d4d4d8; font-family: "SF Mono", Menlo, monospace; }
+  .verify-tooltip .tip-meta:empty { display: none; }
+  .verify-info:hover .verify-tooltip,
+  .verify-info:focus .verify-tooltip { opacity: 1; }
+  .step-panel-head .head-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
   .status-title {
     font-size: 13px;
     font-weight: 500;
@@ -770,46 +879,64 @@ export function getLauncherHtml(): string {
   </div>
 
   <div class="view" id="view-remote-form">
-    <div class="section-title">Connect to Remote Paperclip</div>
+    <div class="section-title">Connect to Remote</div>
+    <div class="section-subtitle">Verify the remote before continuing. HTTP connections require explicit confirmation.</div>
 
-    <div class="form-group">
-      <label for="remoteUrl">Remote URL</label>
-      <input type="text" id="remoteUrl" placeholder="https://paperclip.example.com">
-      <div class="field-hint">Desktop verifies /api/health and auth readiness before loading a remote origin. HTTPS is recommended; HTTP requires an explicit insecure-connection acknowledgment.</div>
-      <div class="field-error" id="urlError">Enter a valid remote URL.</div>
-      <div class="field-success" id="urlSuccess">Verified authenticated Paperclip remote detected.</div>
-    </div>
-
-    <div class="status-card warning-card" id="httpWarningCard">
-      <div class="warning-header">
-        <div class="status-badge warning"><div class="dot"></div>Insecure HTTP</div>
-        <span class="warning-info" tabindex="0" aria-label="More information">?<span class="warning-tooltip" id="httpWarningDetail">This URL disables TLS. Only continue if you trust the network path to this remote. Connect and save stay disabled until you acknowledge.</span></span>
-      </div>
-      <div class="remember-row">
-        <input type="checkbox" id="allowInsecureHttp">
-        <label for="allowInsecureHttp">I understand the risk and want to allow this HTTP connection</label>
+    <div class="step-panel" id="stepPanelUrl">
+      <div class="step-panel-head"><span>Remote URL</span></div>
+      <div class="step-panel-body">
+        <div class="form-group">
+          <input type="text" id="remoteUrl" placeholder="https://paperclip.example.com">
+          <div class="field-hint">Desktop verifies /api/health and auth readiness. HTTPS recommended; HTTP requires acknowledgment.</div>
+          <div class="field-error" id="urlError">Enter a valid remote URL.</div>
+          <div class="field-success" id="urlSuccess">Verified authenticated Paperclip remote detected.</div>
+        </div>
       </div>
     </div>
 
-    <div class="form-group">
-      <label for="displayName">Display name <span style="color:#3f3f46">(optional)</span></label>
-      <input type="text" id="displayName" placeholder="e.g. Home Server">
+    <div class="step-panel" id="stepPanelVerify">
+      <div class="step-panel-head">
+        <span>Verification</span>
+        <div class="head-right">
+          <div id="testStatus"></div>
+          <span class="verify-info" id="verifyInfo" tabindex="0" aria-label="Verification details">i<span class="verify-tooltip"><span class="tip-detail" id="statusDetail">Run verification to inspect deployment mode, auth readiness, and sign-in state.</span><span class="tip-meta" id="statusTipMeta"></span></span></span>
+        </div>
+      </div>
+      <div class="step-panel-body">
+        <div class="status-card" id="statusCard" hidden>
+          <div class="status-title" id="statusTitle" hidden>Waiting for verification</div>
+          <div class="status-meta" id="statusMeta" hidden></div>
+        </div>
+        <div class="status-card warning-card" id="httpWarningCard">
+          <div class="warning-header">
+            <div class="status-badge warning"><div class="dot"></div>Insecure HTTP</div>
+            <span class="warning-info" tabindex="0" aria-label="More information">?<span class="warning-tooltip" id="httpWarningDetail">This URL disables TLS. Only continue if you trust the network path to this remote. Connect and save stay disabled until you acknowledge.</span></span>
+          </div>
+          <div class="remember-row">
+            <input type="checkbox" id="allowInsecureHttp">
+            <label for="allowInsecureHttp">I understand the risk and want to allow this HTTP connection</label>
+          </div>
+        </div>
+        <div class="step-placeholder" id="verifyPlaceholder">Run verify to inspect deployment mode, auth readiness, and sign-in state.</div>
+      </div>
     </div>
 
-    <div class="remember-row" style="margin-top:4px;">
-      <input type="checkbox" id="rememberRemoteForm">
-      <label for="rememberRemoteForm">Reconnect to this remote on launch</label>
-    </div>
-
-    <div id="testStatus" style="min-height: 24px;"></div>
-    <div class="status-card" id="statusCard">
-      <div class="status-title" id="statusTitle">Waiting for verification</div>
-      <div class="status-detail" id="statusDetail">Run verification to inspect deployment mode, auth readiness, and sign-in state.</div>
-      <div class="status-meta" id="statusMeta"></div>
+    <div class="step-panel" id="stepPanelSave">
+      <div class="step-panel-head"><span>Save &amp; connect</span></div>
+      <div class="step-panel-body">
+        <div class="form-group">
+          <label for="displayName">Display name <span style="color:#3f3f46">(optional)</span></label>
+          <input type="text" id="displayName" placeholder="e.g. Home Server">
+        </div>
+        <div class="remember-row" style="margin-bottom:0;">
+          <input type="checkbox" id="rememberRemoteForm">
+          <label for="rememberRemoteForm">Reconnect to this remote on launch</label>
+        </div>
+      </div>
     </div>
 
     <div class="form-actions">
-      <button class="btn" onclick="verifyRemote()">Verify Remote</button>
+      <button class="btn" id="verifyBtn" onclick="verifyRemote()">Verify Remote</button>
       <button class="btn primary" id="signinBtn" onclick="continueToSignIn()" disabled>Continue to Sign-In</button>
       <button class="btn" id="saveBtn" onclick="connectAndSave()" disabled>Connect &amp; Save</button>
     </div>
@@ -1001,20 +1128,33 @@ function setInsecureHttpUi(section, required, checked, detailText) {
   requestContentHeightReport();
 }
 
-function syncRemoteActionButtons() {
+function remoteHttpVerificationRequiresAck() {
+  const remoteUrl = (document.getElementById("remoteUrl")?.value || "").trim();
+  return isInsecureHttpUrl(remoteUrl) && !getRemoteInsecureHttpChoice();
+}
+
+function syncRemoteActionButtons(verifying = false) {
+  const verifyBtn = document.getElementById("verifyBtn");
   const signinBtn = document.getElementById("signinBtn");
   const saveBtn = document.getElementById("saveBtn");
-  if (!signinBtn || !saveBtn) {
+  const placeholder = document.getElementById("verifyPlaceholder");
+  if (!verifyBtn || !signinBtn || !saveBtn) {
     return;
   }
 
+  const requiresHttpAck = remoteHttpVerificationRequiresAck();
   const canProceed = !!(
     lastVerification
     && lastVerification.ok
     && (!lastVerification.insecureTransport || getRemoteInsecureHttpChoice())
   );
+  verifyBtn.disabled = verifying || requiresHttpAck;
+  verifyBtn.textContent = verifying ? "Verifying..." : "Verify Remote";
   signinBtn.disabled = !canProceed;
   saveBtn.disabled = !canProceed;
+  if (placeholder) {
+    placeholder.style.display = (lastVerification || verifying || requiresHttpAck) ? "none" : "block";
+  }
 }
 
 function showView(name) {
@@ -1139,6 +1279,7 @@ async function launchLocal() {
 function openAddRemoteFromChooser() {
   launcher.setChooserMode("remote_existing");
   setInsecureHttpUi("remote", isInsecureHttpUrl(document.getElementById("remoteUrl").value), false);
+  resetVerificationUi();
   showView("remote-form");
 }
 
@@ -1148,9 +1289,9 @@ function resetVerificationUi() {
   document.getElementById("urlSuccess").style.display = "none";
   document.getElementById("testStatus").innerHTML = "";
   document.getElementById("statusCard").classList.remove("active");
-  document.getElementById("signinBtn").disabled = true;
-  document.getElementById("saveBtn").disabled = true;
+  document.getElementById("verifyInfo")?.classList.remove("visible");
   setInsecureHttpUi("remote", isInsecureHttpUrl(document.getElementById("remoteUrl").value), getRemoteInsecureHttpChoice());
+  syncRemoteActionButtons();
 }
 
 function renderStatus(result) {
@@ -1169,6 +1310,16 @@ function renderStatus(result) {
   title.textContent = mapped.title;
   detail.textContent = mapped.detail;
   meta.innerHTML = mapped.meta.map((item) => '<span class="pill">' + escapeHtml(item) + "</span>").join("");
+  const tipMeta = document.getElementById("statusTipMeta");
+  if (tipMeta) {
+    tipMeta.innerHTML = mapped.meta.map((item) => {
+      const idx = item.indexOf("=");
+      const k = idx === -1 ? item : item.slice(0, idx);
+      const v = idx === -1 ? "" : item.slice(idx + 1);
+      return '<span class="k">' + escapeHtml(k) + '</span><span class="v">' + escapeHtml(v) + "</span>";
+    }).join("");
+  }
+  document.getElementById("verifyInfo")?.classList.add("visible");
 
   success.style.display = mapped.success ? "block" : "none";
   signinBtn.textContent = mapped.actionLabel;
@@ -1189,10 +1340,15 @@ async function verifyRemote() {
     return;
   }
 
-  const verifyBtn = document.querySelector("#view-remote-form .form-actions .btn:first-child");
-  verifyBtn.disabled = true;
-  verifyBtn.textContent = "Verifying...";
+  if (remoteHttpVerificationRequiresAck()) {
+    document.getElementById("urlError").textContent = "Confirm the insecure HTTP warning before verifying this connection.";
+    document.getElementById("urlError").style.display = "block";
+    return;
+  }
+
+  const verifyBtn = document.getElementById("verifyBtn");
   document.getElementById("testStatus").innerHTML = '<div class="status-badge testing"><div class="dot"></div>Verifying remote...</div>';
+  syncRemoteActionButtons(true);
 
   try {
     const result = await launcher.verifyRemote({ remoteUrl });
@@ -1208,8 +1364,8 @@ async function verifyRemote() {
     setInsecureHttpUi("remote", result.insecureTransport, getRemoteInsecureHttpChoice(), result.warning);
     renderStatus(result);
   } finally {
-    verifyBtn.disabled = false;
     verifyBtn.textContent = "Verify Remote";
+    syncRemoteActionButtons();
   }
 }
 
@@ -1885,7 +2041,9 @@ window.paperclipLauncher.onNavigate((payload) => {
     if (payload.profile) {
       document.getElementById("remoteUrl").value = payload.profile.remoteUrl || "";
       document.getElementById("displayName").value = payload.profile.name || "";
+      setInsecureHttpUi("remote", isInsecureHttpUrl(payload.profile.remoteUrl), !!payload.profile.allowInsecureHttp);
     }
+    resetVerificationUi();
     showView("remote-form");
     return;
   }

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -278,6 +278,69 @@ export function getLauncherHtml(): string {
     text-align: left;
   }
   .status-card.active { display: block; }
+  .status-card.warning-card {
+    border-color: #3f3220;
+    background: #17130d;
+    padding: 10px 12px;
+  }
+  .status-card.warning-card .warning-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+  }
+  .status-card.warning-card .warning-header .status-badge {
+    margin-bottom: 0;
+  }
+  .status-card.warning-card .warning-info {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #3f3220;
+    color: #fbbf24;
+    font-size: 10px;
+    font-weight: 600;
+    cursor: help;
+    user-select: none;
+  }
+  .status-card.warning-card .warning-info .warning-tooltip {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 260px;
+    padding: 8px 10px;
+    background: #0a0a0b;
+    border: 1px solid #3f3220;
+    border-radius: 6px;
+    color: #d4d4d8;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.4;
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    z-index: 10;
+    white-space: normal;
+  }
+  .status-card.warning-card .warning-info:hover .warning-tooltip,
+  .status-card.warning-card .warning-info:focus .warning-tooltip {
+    opacity: 1;
+  }
+  .status-card.warning-card .remember-row {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #d4d4d8;
+    font-size: 12px;
+  }
+  .status-card.warning-card .remember-row label {
+    color: inherit;
+  }
   .status-title {
     font-size: 13px;
     font-weight: 500;
@@ -520,6 +583,10 @@ export function getLauncherHtml(): string {
   }
   .modal .form-group { width: 100%; }
   .modal .form-actions { justify-content: flex-end; }
+  .modal .status-card {
+    width: 100%;
+    margin-bottom: 16px;
+  }
 
   .progress-track {
     width: 240px;
@@ -708,9 +775,20 @@ export function getLauncherHtml(): string {
     <div class="form-group">
       <label for="remoteUrl">Remote URL</label>
       <input type="text" id="remoteUrl" placeholder="https://paperclip.example.com">
-      <div class="field-hint">Desktop verifies /api/health and auth readiness before loading a remote origin. Public remotes must use HTTPS; local/private hosts can use HTTP.</div>
+      <div class="field-hint">Desktop verifies /api/health and auth readiness before loading a remote origin. HTTPS is recommended; HTTP requires an explicit insecure-connection acknowledgment.</div>
       <div class="field-error" id="urlError">Enter a valid remote URL.</div>
       <div class="field-success" id="urlSuccess">Verified authenticated Paperclip remote detected.</div>
+    </div>
+
+    <div class="status-card warning-card" id="httpWarningCard">
+      <div class="warning-header">
+        <div class="status-badge warning"><div class="dot"></div>Insecure HTTP</div>
+        <span class="warning-info" tabindex="0" aria-label="More information">?<span class="warning-tooltip" id="httpWarningDetail">This URL disables TLS. Only continue if you trust the network path to this remote. Connect and save stay disabled until you acknowledge.</span></span>
+      </div>
+      <div class="remember-row">
+        <input type="checkbox" id="allowInsecureHttp">
+        <label for="allowInsecureHttp">I understand the risk and want to allow this HTTP connection</label>
+      </div>
     </div>
 
     <div class="form-group">
@@ -811,8 +889,19 @@ export function getLauncherHtml(): string {
     <div class="form-group">
       <label for="modalUrl">URL</label>
       <input type="text" id="modalUrl" placeholder="https://paperclip.example.com">
-      <div class="field-hint">Remote profiles are verified before use and never store raw passwords.</div>
+      <div class="field-hint">Remote profiles are verified before use and never store raw passwords. HTTP profiles require an explicit insecure-connection acknowledgment.</div>
       <div class="field-error" id="modalError">Enter a valid remote URL.</div>
+    </div>
+
+    <div class="status-card warning-card" id="modalHttpWarningCard">
+      <div class="warning-header">
+        <div class="status-badge warning"><div class="dot"></div>Insecure HTTP</div>
+        <span class="warning-info" tabindex="0" aria-label="More information">?<span class="warning-tooltip" id="modalHttpWarningDetail">Saving this URL means future reconnects can reuse plaintext HTTP unless you switch it back to HTTPS. Use only when you trust the network path.</span></span>
+      </div>
+      <div class="remember-row">
+        <input type="checkbox" id="modalAllowInsecureHttp">
+        <label for="modalAllowInsecureHttp">I understand the risk and want to save this HTTP connection</label>
+      </div>
     </div>
 
     <div class="form-actions">
@@ -867,6 +956,65 @@ function setRemoteRememberChoice(checked) {
   const form = document.getElementById("rememberRemoteForm");
   if (chooser) chooser.checked = !!checked;
   if (form) form.checked = !!checked;
+}
+
+function isInsecureHttpUrl(value) {
+  return String(value || "").trim().toLowerCase().startsWith("http://");
+}
+
+function getRemoteInsecureHttpChoice() {
+  return !!document.getElementById("allowInsecureHttp")?.checked;
+}
+
+function setRemoteInsecureHttpChoice(checked) {
+  const checkbox = document.getElementById("allowInsecureHttp");
+  if (checkbox) checkbox.checked = !!checked;
+}
+
+function getModalInsecureHttpChoice() {
+  return !!document.getElementById("modalAllowInsecureHttp")?.checked;
+}
+
+function setModalInsecureHttpChoice(checked) {
+  const checkbox = document.getElementById("modalAllowInsecureHttp");
+  if (checkbox) checkbox.checked = !!checked;
+}
+
+function setInsecureHttpUi(section, required, checked, detailText) {
+  const card = document.getElementById(section === "remote" ? "httpWarningCard" : "modalHttpWarningCard");
+  const detail = document.getElementById(section === "remote" ? "httpWarningDetail" : "modalHttpWarningDetail");
+  const setChoice = section === "remote" ? setRemoteInsecureHttpChoice : setModalInsecureHttpChoice;
+
+  card.classList.toggle("active", required);
+  if (detail) {
+    detail.textContent = detailText || (
+      section === "remote"
+        ? "This URL disables TLS. Only continue if you trust the network path to this remote."
+        : "Saving this URL means future reconnects can reuse plaintext HTTP unless you switch it back to HTTPS."
+    );
+  }
+  setChoice(required ? checked : false);
+
+  if (section === "remote") {
+    syncRemoteActionButtons();
+  }
+  requestContentHeightReport();
+}
+
+function syncRemoteActionButtons() {
+  const signinBtn = document.getElementById("signinBtn");
+  const saveBtn = document.getElementById("saveBtn");
+  if (!signinBtn || !saveBtn) {
+    return;
+  }
+
+  const canProceed = !!(
+    lastVerification
+    && lastVerification.ok
+    && (!lastVerification.insecureTransport || getRemoteInsecureHttpChoice())
+  );
+  signinBtn.disabled = !canProceed;
+  saveBtn.disabled = !canProceed;
 }
 
 function showView(name) {
@@ -990,16 +1138,19 @@ async function launchLocal() {
 
 function openAddRemoteFromChooser() {
   launcher.setChooserMode("remote_existing");
+  setInsecureHttpUi("remote", isInsecureHttpUrl(document.getElementById("remoteUrl").value), false);
   showView("remote-form");
 }
 
 function resetVerificationUi() {
+  lastVerification = null;
   document.getElementById("urlError").style.display = "none";
   document.getElementById("urlSuccess").style.display = "none";
   document.getElementById("testStatus").innerHTML = "";
   document.getElementById("statusCard").classList.remove("active");
   document.getElementById("signinBtn").disabled = true;
   document.getElementById("saveBtn").disabled = true;
+  setInsecureHttpUi("remote", isInsecureHttpUrl(document.getElementById("remoteUrl").value), getRemoteInsecureHttpChoice());
 }
 
 function renderStatus(result) {
@@ -1024,6 +1175,8 @@ function renderStatus(result) {
   saveBtn.textContent = mapped.saveLabel;
   signinBtn.disabled = !mapped.success;
   saveBtn.disabled = !mapped.success;
+  setInsecureHttpUi("remote", result.insecureTransport, getRemoteInsecureHttpChoice(), result.warning);
+  syncRemoteActionButtons();
 }
 
 async function verifyRemote() {
@@ -1052,6 +1205,7 @@ async function verifyRemote() {
       return;
     }
 
+    setInsecureHttpUi("remote", result.insecureTransport, getRemoteInsecureHttpChoice(), result.warning);
     renderStatus(result);
   } finally {
     verifyBtn.disabled = false;
@@ -1064,6 +1218,13 @@ async function continueToSignIn() {
     return;
   }
 
+  const allowInsecureHttp = getRemoteInsecureHttpChoice();
+  if (lastVerification.insecureTransport && !allowInsecureHttp) {
+    document.getElementById("urlError").textContent = "Confirm the insecure HTTP warning before connecting.";
+    document.getElementById("urlError").style.display = "block";
+    return;
+  }
+
   const rememberChoice = getRemoteRememberChoice();
   const remoteUrl = document.getElementById("remoteUrl").value.trim();
   const displayName = document.getElementById("displayName").value.trim();
@@ -1073,6 +1234,7 @@ async function continueToSignIn() {
     rememberChoice,
     remoteUrl,
     displayName,
+    allowInsecureHttp,
   };
 
   showRemoteConnectingState(lastVerification);
@@ -1081,11 +1243,19 @@ async function continueToSignIn() {
     displayName,
     saveProfile: false,
     rememberChoice,
+    allowInsecureHttp,
   });
 }
 
 async function connectAndSave() {
   if (!lastVerification || !lastVerification.ok) {
+    document.getElementById("urlError").style.display = "block";
+    return;
+  }
+
+  const allowInsecureHttp = getRemoteInsecureHttpChoice();
+  if (lastVerification.insecureTransport && !allowInsecureHttp) {
+    document.getElementById("urlError").textContent = "Confirm the insecure HTTP warning before saving or connecting.";
     document.getElementById("urlError").style.display = "block";
     return;
   }
@@ -1099,6 +1269,7 @@ async function connectAndSave() {
     rememberChoice,
     remoteUrl,
     displayName,
+    allowInsecureHttp,
   };
 
   showRemoteConnectingState(lastVerification);
@@ -1107,6 +1278,7 @@ async function connectAndSave() {
     displayName,
     saveProfile: true,
     rememberChoice,
+    allowInsecureHttp,
   });
 }
 
@@ -1124,17 +1296,27 @@ async function retryLastAction() {
 
   document.getElementById("remoteUrl").value = lastErrorAction.remoteUrl || "";
   document.getElementById("displayName").value = lastErrorAction.displayName || "";
+  setInsecureHttpUi("remote", isInsecureHttpUrl(lastErrorAction.remoteUrl), !!lastErrorAction.allowInsecureHttp);
   showRemoteConnectingState(lastVerification || {
     ok: true,
+    insecureTransport: isInsecureHttpUrl(lastErrorAction.remoteUrl),
+    origin: "",
+    paperclipDetected: true,
+    deploymentMode: null,
+    deploymentExposure: null,
+    authReady: null,
     sessionState: "signed_out",
     bootstrapStatus: null,
+    bootstrapInviteActive: null,
     normalizedUrl: lastErrorAction.remoteUrl,
+    version: null,
   });
   await launcher.connectRemote({
     remoteUrl: lastErrorAction.remoteUrl,
     displayName: lastErrorAction.displayName,
     saveProfile: !!lastErrorAction.saveProfile,
     rememberChoice: !!lastErrorAction.rememberChoice,
+    allowInsecureHttp: !!lastErrorAction.allowInsecureHttp,
   });
 }
 
@@ -1239,6 +1421,7 @@ function openAddModal() {
   document.getElementById("modalName").value = "";
   document.getElementById("modalUrl").value = "";
   document.getElementById("modalError").style.display = "none";
+  setInsecureHttpUi("modal", false, false);
   document.getElementById("editModal").classList.add("active");
 }
 
@@ -1255,11 +1438,13 @@ function openEditModal(profileId) {
   document.getElementById("modalName").value = profile.name;
   document.getElementById("modalUrl").value = profile.remoteUrl || "";
   document.getElementById("modalError").style.display = "none";
+  setInsecureHttpUi("modal", isInsecureHttpUrl(profile.remoteUrl), !!profile.allowInsecureHttp);
   document.getElementById("editModal").classList.add("active");
 }
 
 function closeModal() {
   editingId = null;
+  setInsecureHttpUi("modal", false, false);
   document.getElementById("editModal").classList.remove("active");
 }
 
@@ -1281,6 +1466,7 @@ async function saveModal() {
       profileId: editingId || undefined,
       name,
       remoteUrl,
+      allowInsecureHttp: getModalInsecureHttpChoice(),
     });
     applySnapshot(nextSnapshot);
     closeModal();
@@ -1348,12 +1534,14 @@ async function quickConnect(profileId) {
   const rememberChoice = getRemoteRememberChoice();
   document.getElementById("remoteUrl").value = profile.remoteUrl || "";
   document.getElementById("displayName").value = profile.name;
+  setInsecureHttpUi("remote", isInsecureHttpUrl(profile.remoteUrl), !!profile.allowInsecureHttp);
   lastErrorAction = {
     type: "remote",
     saveProfile: false,
     rememberChoice,
     remoteUrl: profile.remoteUrl,
     displayName: profile.name,
+    allowInsecureHttp: !!profile.allowInsecureHttp,
   };
   document.getElementById("connectingLabel").textContent = "Opening verified remote...";
   document.getElementById("connectingUrl").textContent = profile.remoteUrl || "";
@@ -1424,17 +1612,18 @@ function capabilityLabel(profile) {
     return "Local embedded";
   }
 
+  const suffix = profile.allowInsecureHttp ? " / insecure HTTP" : "";
   switch (profile.lastHealth) {
     case "healthy":
-      return "Authenticated / session active";
+      return "Authenticated / session active" + suffix;
     case "auth_required":
-      return "Authenticated / sign-in required";
+      return "Authenticated / sign-in required" + suffix;
     case "unsupported":
-      return "Blocked: unsupported remote";
+      return "Blocked: unsupported remote" + suffix;
     case "unreachable":
-      return "Host unreachable";
+      return "Host unreachable" + suffix;
     default:
-      return "Pending verification";
+      return "Pending verification" + suffix;
   }
 }
 
@@ -1843,6 +2032,23 @@ document.addEventListener("keydown", (event) => {
 // ---------------------------------------------------------------------------
 
 document.addEventListener("DOMContentLoaded", async () => {
+  document.getElementById("remoteUrl")?.addEventListener("input", (event) => {
+    const remoteUrl = event.target.value;
+    setInsecureHttpUi("remote", isInsecureHttpUrl(remoteUrl), getRemoteInsecureHttpChoice());
+    resetVerificationUi();
+  });
+  document.getElementById("allowInsecureHttp")?.addEventListener("change", () => {
+    document.getElementById("urlError").style.display = "none";
+    syncRemoteActionButtons();
+  });
+  document.getElementById("modalUrl")?.addEventListener("input", (event) => {
+    setInsecureHttpUi("modal", isInsecureHttpUrl(event.target.value), getModalInsecureHttpChoice());
+    document.getElementById("modalError").style.display = "none";
+  });
+  document.getElementById("modalAllowInsecureHttp")?.addEventListener("change", () => {
+    document.getElementById("modalError").style.display = "none";
+  });
+
   const initialSnapshot = await launcher.bootstrap();
   applySnapshot(initialSnapshot);
   showView(initialSnapshot.initialView || "chooser");

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -708,8 +708,8 @@ export function getLauncherHtml(): string {
     <div class="form-group">
       <label for="remoteUrl">Remote URL</label>
       <input type="text" id="remoteUrl" placeholder="https://paperclip.example.com">
-      <div class="field-hint">Desktop requires HTTPS and verifies /api/health and auth readiness before loading a remote origin.</div>
-      <div class="field-error" id="urlError">Enter a valid HTTPS URL.</div>
+      <div class="field-hint">Desktop verifies /api/health and auth readiness before loading a remote origin. Public remotes must use HTTPS; local/private hosts can use HTTP.</div>
+      <div class="field-error" id="urlError">Enter a valid remote URL.</div>
       <div class="field-success" id="urlSuccess">Verified authenticated Paperclip remote detected.</div>
     </div>
 
@@ -812,7 +812,7 @@ export function getLauncherHtml(): string {
       <label for="modalUrl">URL</label>
       <input type="text" id="modalUrl" placeholder="https://paperclip.example.com">
       <div class="field-hint">Remote profiles are verified before use and never store raw passwords.</div>
-      <div class="field-error" id="modalError">Enter a valid HTTPS URL.</div>
+      <div class="field-error" id="modalError">Enter a valid remote URL.</div>
     </div>
 
     <div class="form-actions">
@@ -1031,7 +1031,7 @@ async function verifyRemote() {
   resetVerificationUi();
 
   if (!remoteUrl) {
-    document.getElementById("urlError").textContent = "Enter a valid HTTPS URL.";
+    document.getElementById("urlError").textContent = "Enter a valid remote URL.";
     document.getElementById("urlError").style.display = "block";
     return;
   }
@@ -1047,7 +1047,7 @@ async function verifyRemote() {
 
     if (result.reason === "invalid_url") {
       document.getElementById("testStatus").innerHTML = "";
-      document.getElementById("urlError").textContent = result.detail || "Enter a valid HTTPS URL.";
+      document.getElementById("urlError").textContent = result.detail || "Enter a valid remote URL.";
       document.getElementById("urlError").style.display = "block";
       return;
     }
@@ -1286,7 +1286,7 @@ async function saveModal() {
     closeModal();
     restoreModalReturnView();
   } catch (error) {
-    document.getElementById("modalError").textContent = error && error.message ? error.message : "Enter a valid HTTPS URL.";
+    document.getElementById("modalError").textContent = error && error.message ? error.message : "Enter a valid remote URL.";
     document.getElementById("modalError").style.display = "block";
   }
 }

--- a/src/launcher-preload.ts
+++ b/src/launcher-preload.ts
@@ -4,7 +4,7 @@ contextBridge.exposeInMainWorld("paperclipLauncher", {
   bootstrap: () => ipcRenderer.invoke("launcher:bootstrap"),
   setChooserMode: (mode: "local_embedded" | "remote_existing") =>
     ipcRenderer.invoke("launcher:set-chooser-mode", mode),
-  saveRemoteProfile: (payload: { profileId?: string; name?: string; remoteUrl: string }) =>
+  saveRemoteProfile: (payload: { profileId?: string; name?: string; remoteUrl: string; allowInsecureHttp?: boolean }) =>
     ipcRenderer.invoke("launcher:save-remote-profile", payload),
   duplicateProfile: (profileId: string) => ipcRenderer.invoke("launcher:duplicate-profile", profileId),
   deleteProfile: (profileId: string) => ipcRenderer.invoke("launcher:delete-profile", profileId),
@@ -16,6 +16,7 @@ contextBridge.exposeInMainWorld("paperclipLauncher", {
     displayName?: string;
     saveProfile: boolean;
     rememberChoice: boolean;
+    allowInsecureHttp?: boolean;
   }) => ipcRenderer.invoke("launcher:connect-remote", payload),
   connectSavedProfile: (payload: { profileId: string; rememberChoice: boolean }) =>
     ipcRenderer.invoke("launcher:connect-saved-profile", payload),

--- a/src/main.ts
+++ b/src/main.ts
@@ -1085,6 +1085,7 @@ async function bootRemote(options: {
   saveProfile: boolean;
   rememberChoiceExplicit?: boolean;
   rememberChoice?: boolean;
+  allowInsecureHttp?: boolean;
 }): Promise<void> {
   const bootId = ++bootSequence;
   const previousConnectionMode = currentConnection?.mode ?? null;
@@ -1092,6 +1093,9 @@ async function bootRemote(options: {
   let normalized;
   try {
     normalized = normalizeRemoteUrl(options.remoteUrl);
+    if (normalized.insecureTransport && options.allowInsecureHttp !== true) {
+      throw new Error("HTTP remotes require confirming that you want to allow an insecure connection.");
+    }
   } catch (error) {
     await ensureLauncherWindow("remote-form");
     sendConnectionError(
@@ -1140,12 +1144,13 @@ async function bootRemote(options: {
 
   let savedProfile: ConnectionProfile | null = null;
   if (options.profileId) {
-    connectionStore.syncRemoteProfileUrl(options.profileId, result.normalizedUrl);
+    connectionStore.syncRemoteProfileUrl(options.profileId, result.normalizedUrl, result.insecureTransport);
     savedProfile = connectionStore.getProfile(options.profileId);
   } else if (options.saveProfile || options.rememberChoice) {
     savedProfile = connectionStore.saveRemoteProfile({
       name: options.displayName,
       remoteUrl: result.normalizedUrl,
+      allowInsecureHttp: result.insecureTransport,
     });
   }
 
@@ -1228,6 +1233,7 @@ async function bootSavedProfile(
     saveProfile: false,
     rememberChoiceExplicit: options.rememberChoiceExplicit,
     rememberChoice: options.rememberChoice,
+    allowInsecureHttp: profile.allowInsecureHttp,
   });
 }
 
@@ -1246,7 +1252,7 @@ function registerLauncherIpc(): void {
 
   ipcMain.handle(
     "launcher:save-remote-profile",
-    (_event, payload: { profileId?: string; name?: string; remoteUrl: string }) => {
+    (_event, payload: { profileId?: string; name?: string; remoteUrl: string; allowInsecureHttp?: boolean }) => {
       connectionStore.saveRemoteProfile(payload);
       sendLauncherState();
       return buildLauncherSnapshot();
@@ -1296,6 +1302,7 @@ function registerLauncherIpc(): void {
         displayName?: string;
         saveProfile: boolean;
         rememberChoice: boolean;
+        allowInsecureHttp?: boolean;
       },
     ) => {
       void bootRemote({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1096,7 +1096,7 @@ async function bootRemote(options: {
     await ensureLauncherWindow("remote-form");
     sendConnectionError(
       "Invalid remote URL",
-      error instanceof Error ? error.message : "Enter a valid HTTPS URL.",
+      error instanceof Error ? error.message : "Enter a valid remote URL.",
     );
     sendLauncherNavigation("error");
     return;

--- a/test/connection-preflight.test.mjs
+++ b/test/connection-preflight.test.mjs
@@ -35,6 +35,7 @@ test("preflight accepts authenticated Paperclip with active session", async () =
   });
 
   assert.equal(result.ok, true);
+  assert.equal(result.insecureTransport, false);
   assert.equal(result.sessionState, "signed_in");
   assert.equal(result.deploymentMode, "authenticated");
   assert.equal(result.bootstrapStatus, "ready");
@@ -66,6 +67,7 @@ test("preflight treats 401 session probe as sign-in required", async () => {
   });
 
   assert.equal(result.ok, true);
+  assert.equal(result.insecureTransport, false);
   assert.equal(result.sessionState, "signed_out");
   assert.equal(result.bootstrapStatus, "bootstrap_pending");
 });
@@ -89,13 +91,14 @@ test("preflight blocks local_trusted remotes", async () => {
   });
 
   assert.equal(result.ok, false);
+  assert.equal(result.insecureTransport, false);
   assert.equal(result.reason, "unsupported_local_trusted");
 });
 
-test("preflight rejects http remotes before any network call", async () => {
+test("preflight rejects unsupported URL schemes before any network call", async () => {
   let called = false;
   const result = await preflightRemoteConnection({
-    remoteUrl: "http://paperclip.example.com",
+    remoteUrl: "ftp://paperclip.example.com",
     fetchImpl: async () => {
       called = true;
       return jsonResponse({ status: "ok" }, 200);
@@ -104,11 +107,11 @@ test("preflight rejects http remotes before any network call", async () => {
 
   assert.equal(result.ok, false);
   assert.equal(result.reason, "invalid_url");
-  assert.match(result.detail, /https/i);
+  assert.match(result.detail, /http or https/i);
   assert.equal(called, false);
 });
 
-test("preflight allows http remotes on private networks", async () => {
+test("preflight allows http remotes and carries the insecurity warning", async () => {
   const responses = [
     jsonResponse(
       {
@@ -129,13 +132,15 @@ test("preflight allows http remotes on private networks", async () => {
   ];
 
   const result = await preflightRemoteConnection({
-    remoteUrl: "http://paperclip-host.tailnet.ts.net:3200",
+    remoteUrl: "http://paperclip.example.com:3200",
     fetchImpl: async () => responses.shift(),
   });
 
   assert.equal(result.ok, true);
-  assert.equal(result.origin, "http://paperclip-host.tailnet.ts.net:3200");
+  assert.equal(result.insecureTransport, true);
+  assert.equal(result.origin, "http://paperclip.example.com:3200");
   assert.equal(result.sessionState, "signed_out");
+  assert.match(result.warning, /without TLS/i);
 });
 
 test("preflight rejects non-Paperclip endpoints", async () => {
@@ -145,6 +150,7 @@ test("preflight rejects non-Paperclip endpoints", async () => {
   });
 
   assert.equal(result.ok, false);
+  assert.equal(result.insecureTransport, false);
   assert.equal(result.reason, "not_paperclip");
 });
 
@@ -157,6 +163,7 @@ test("preflight classifies TLS failures", async () => {
   });
 
   assert.equal(result.ok, false);
+  assert.equal(result.insecureTransport, false);
   assert.equal(result.reason, "tls_error");
 });
 

--- a/test/connection-preflight.test.mjs
+++ b/test/connection-preflight.test.mjs
@@ -108,6 +108,36 @@ test("preflight rejects http remotes before any network call", async () => {
   assert.equal(called, false);
 });
 
+test("preflight allows http remotes on private networks", async () => {
+  const responses = [
+    jsonResponse(
+      {
+        status: "ok",
+        version: "2026.403.0",
+        deploymentMode: "authenticated",
+        deploymentExposure: "private",
+        authReady: true,
+        bootstrapStatus: "ready",
+        bootstrapInviteActive: false,
+      },
+      200,
+    ),
+    new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+  ];
+
+  const result = await preflightRemoteConnection({
+    remoteUrl: "http://paperclip-host.tailnet.ts.net:3200",
+    fetchImpl: async () => responses.shift(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.origin, "http://paperclip-host.tailnet.ts.net:3200");
+  assert.equal(result.sessionState, "signed_out");
+});
+
 test("preflight rejects non-Paperclip endpoints", async () => {
   const result = await preflightRemoteConnection({
     remoteUrl: "https://example.com",

--- a/test/connection-profiles.test.mjs
+++ b/test/connection-profiles.test.mjs
@@ -26,10 +26,13 @@ test("connection store persists remote profiles and startup preference", () => {
     ok: true,
     normalizedUrl: "https://paperclip-host.tailnet.ts.net/",
     origin: "https://paperclip-host.tailnet.ts.net",
+    insecureTransport: false,
     paperclipDetected: true,
     deploymentMode: "authenticated",
     deploymentExposure: "private",
     authReady: true,
+    bootstrapStatus: null,
+    bootstrapInviteActive: null,
     sessionState: "signed_out",
     version: "2026.403.0",
   });
@@ -69,4 +72,28 @@ test("connection store duplicates and deletes remote profiles", () => {
   assert.equal(profiles.length, 1);
   assert.equal(profiles[0].id, duplicate.id);
   assert.match(profiles[0].name, /\(copy\)$/);
+});
+
+test("connection store requires explicit acknowledgement before saving an HTTP profile", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-http-"));
+  const store = new ConnectionStore(getConnectionsFilePath(tempDir));
+
+  assert.throws(
+    () => store.saveRemoteProfile({
+      name: "Insecure",
+      remoteUrl: "http://paperclip.example.com",
+    }),
+    /allow an insecure connection/i,
+  );
+
+  const profile = store.saveRemoteProfile({
+    name: "Insecure",
+    remoteUrl: "http://paperclip.example.com",
+    allowInsecureHttp: true,
+  });
+  assert.equal(profile.allowInsecureHttp, true);
+
+  const reloaded = new ConnectionStore(getConnectionsFilePath(tempDir));
+  const saved = reloaded.getProfile(profile.id);
+  assert.equal(saved.allowInsecureHttp, true);
 });

--- a/test/connection-validate.test.mjs
+++ b/test/connection-validate.test.mjs
@@ -12,10 +12,28 @@ test("normalizeRemoteUrl strips path and preserves https origin", () => {
   assert.equal(normalized.warning, undefined);
 });
 
-test("normalizeRemoteUrl rejects non-https remotes", () => {
+test("normalizeRemoteUrl allows http remotes on private networks", () => {
+  const tenNet = normalizeRemoteUrl("http://10.0.1.25:3100");
+  assert.equal(tenNet.normalizedUrl, "http://10.0.1.25:3100/");
+  assert.equal(tenNet.origin, "http://10.0.1.25:3100");
+
+  const ipAddress = normalizeRemoteUrl("http://192.168.1.50:3100/dashboard");
+  assert.equal(ipAddress.normalizedUrl, "http://192.168.1.50:3100/");
+  assert.equal(ipAddress.origin, "http://192.168.1.50:3100");
+
+  const tailscaleIp = normalizeRemoteUrl("http://100.100.100.100:3200");
+  assert.equal(tailscaleIp.normalizedUrl, "http://100.100.100.100:3200/");
+  assert.equal(tailscaleIp.origin, "http://100.100.100.100:3200");
+
+  const tailnet = normalizeRemoteUrl("http://paperclip-host.tailnet.ts.net");
+  assert.equal(tailnet.normalizedUrl, "http://paperclip-host.tailnet.ts.net/");
+  assert.equal(tailnet.origin, "http://paperclip-host.tailnet.ts.net");
+});
+
+test("normalizeRemoteUrl rejects public http remotes", () => {
   assert.throws(
     () => normalizeRemoteUrl("http://paperclip.example.com"),
-    /must use HTTPS/i,
+    /must use HTTPS unless the host is on a local or private network/i,
   );
 });
 
@@ -28,6 +46,8 @@ test("normalizeRemoteUrl rejects embedded credentials", () => {
 
 test("isPrivateHostname recognises tailnet and RFC1918 hosts", () => {
   assert.equal(isPrivateHostname("paperclip-host.tailnet.ts.net"), true);
+  assert.equal(isPrivateHostname("10.0.1.25"), true);
   assert.equal(isPrivateHostname("192.168.1.50"), true);
+  assert.equal(isPrivateHostname("100.100.100.100"), true);
   assert.equal(isPrivateHostname("paperclip.example.com"), false);
 });

--- a/test/connection-validate.test.mjs
+++ b/test/connection-validate.test.mjs
@@ -9,13 +9,16 @@ test("normalizeRemoteUrl strips path and preserves https origin", () => {
   const normalized = normalizeRemoteUrl("https://paperclip.example.com/app/dashboard?x=1#top");
   assert.equal(normalized.normalizedUrl, "https://paperclip.example.com/");
   assert.equal(normalized.origin, "https://paperclip.example.com");
+  assert.equal(normalized.insecureTransport, false);
   assert.equal(normalized.warning, undefined);
 });
 
-test("normalizeRemoteUrl allows http remotes on private networks", () => {
+test("normalizeRemoteUrl allows http remotes and attaches an insecurity warning", () => {
   const tenNet = normalizeRemoteUrl("http://10.0.1.25:3100");
   assert.equal(tenNet.normalizedUrl, "http://10.0.1.25:3100/");
   assert.equal(tenNet.origin, "http://10.0.1.25:3100");
+  assert.equal(tenNet.insecureTransport, true);
+  assert.match(tenNet.warning, /without TLS/i);
 
   const ipAddress = normalizeRemoteUrl("http://192.168.1.50:3100/dashboard");
   assert.equal(ipAddress.normalizedUrl, "http://192.168.1.50:3100/");
@@ -28,13 +31,11 @@ test("normalizeRemoteUrl allows http remotes on private networks", () => {
   const tailnet = normalizeRemoteUrl("http://paperclip-host.tailnet.ts.net");
   assert.equal(tailnet.normalizedUrl, "http://paperclip-host.tailnet.ts.net/");
   assert.equal(tailnet.origin, "http://paperclip-host.tailnet.ts.net");
-});
+  assert.match(tailnet.warning, /trust the local or private network/i);
 
-test("normalizeRemoteUrl rejects public http remotes", () => {
-  assert.throws(
-    () => normalizeRemoteUrl("http://paperclip.example.com"),
-    /must use HTTPS unless the host is on a local or private network/i,
-  );
+  const publicHost = normalizeRemoteUrl("http://paperclip.example.com");
+  assert.equal(publicHost.normalizedUrl, "http://paperclip.example.com/");
+  assert.match(publicHost.warning, /risk is higher/i);
 });
 
 test("normalizeRemoteUrl rejects embedded credentials", () => {
@@ -49,5 +50,7 @@ test("isPrivateHostname recognises tailnet and RFC1918 hosts", () => {
   assert.equal(isPrivateHostname("10.0.1.25"), true);
   assert.equal(isPrivateHostname("192.168.1.50"), true);
   assert.equal(isPrivateHostname("100.100.100.100"), true);
+  assert.equal(isPrivateHostname("[::1]"), true);
+  assert.equal(isPrivateHostname("[fd00::1]"), true);
   assert.equal(isPrivateHostname("paperclip.example.com"), false);
 });


### PR DESCRIPTION
 ## Summary

  Allow remote connections over http for local/private hosts while keeping https required for public remotes.

  ## Changes

  - Updated remote URL normalization to accept http only for private/local targets.
  - Kept public http remotes blocked.
  - Reused existing private-host detection for:
      - 10.0.0.0/8
      - 172.16.0.0/12
      - 192.168.0.0/16
      - loopback/link-local ranges
      - 100.64.0.0/10 (Tailscale-style IP range)
      - private hostnames like .ts.net
  - Updated launcher copy and validation messaging to reflect the new rule.

  ## Why

  Some remote Paperclip instances are intentionally exposed over private-network http, such as Tailscale or LAN-only deployments. The previous validation rejected all http URLs before preflight could run,
  which blocked legitimate private-network remotes.

  ## Tests

  Added coverage for:

  - private http remotes being accepted
  - public http remotes being rejected
  - Tailscale hostname/IP cases
  - preflight allowing private-network http


<img width="1024" height="1226" alt="CleanShot 2026-04-13 at 08 21 28@2x" src="https://github.com/user-attachments/assets/6c129bb7-2bca-415b-9caf-af6ef8979496" />
<img width="1026" height="1384" alt="CleanShot 2026-04-13 at 08 21 52@2x" src="https://github.com/user-attachments/assets/552129a8-3beb-481b-a652-cb06f9a7ec58" />

