### PR TITLE
Windows: ship-ready build with repair and uninstall flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ build/server-bundle/
 build/server-staging/
 build/node-bin/
 build/upstream-clone/
+build/ui-staging/
 docs/development/paperclip/
 docs/mockups/chooser-variations.html
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,19 @@
+; Paperclip Desktop — custom NSIS hooks
+; Adds an "also delete user data" prompt to the uninstaller, so users get
+; a clean removal option without having to dig into %APPDATA% themselves.
+
+!macro customUnInstall
+  ; Don't prompt during silent uninstall (e.g. installer self-replace on update)
+  ${ifNot} ${isUpdated}
+    MessageBox MB_YESNO|MB_ICONQUESTION \
+      "Also delete Paperclip's local data?$\r$\n$\r$\nThis removes your databases, saved connections, and settings under:$\r$\n$APPDATA\Paperclip$\r$\n$LOCALAPPDATA\Paperclip$\r$\n$PROFILE\.paperclip$\r$\n$\r$\nChoose No to keep your data for a future reinstall." \
+      /SD IDNO \
+      IDNO skipUserDataWipe
+
+    RMDir /r "$APPDATA\Paperclip"
+    RMDir /r "$LOCALAPPDATA\Paperclip"
+    RMDir /r "$PROFILE\.paperclip"
+
+    skipUserDataWipe:
+  ${endIf}
+!macroend

--- a/docs/development/windows-troubleshooting.md
+++ b/docs/development/windows-troubleshooting.md
@@ -1,0 +1,91 @@
+# Windows Troubleshooting Guide
+
+Support-oriented guide for diagnosing Paperclip Desktop install, boot, and shutdown problems on Windows. The affordances described here ship in the app as of the Windows release work in `docs/prds/windows-release.md`.
+
+## Where Logs Live
+
+Paperclip writes two log streams on Windows. Both are useful, but the inner server log is the one that contains real boot errors and stack traces.
+
+| Log | Path | What it contains |
+| --- | --- | --- |
+| Electron-side | `%APPDATA%\Paperclip\server.log` | One block per boot attempt: which `node.exe` was used, which server entrypoint was spawned, and a copy of every line emitted on stdout/stderr by the spawned server. |
+| Server-side (pino) | `%USERPROFILE%\.paperclip\instances\default\logs\server.log` (or `%APPDATA%\Paperclip\instances\default\logs\server.log` if `~/.paperclip` is not in use) | The bundled `@paperclipai/server` writes here through pino. This is the only place you will see embedded-postgres init errors, migration failures, and most native-binary blocked-by-AV traces. |
+
+The fastest way to open both is `Help → Open Application Logs` from the Paperclip menu bar. That opens `%APPDATA%\Paperclip` in Explorer; the server-side logs live one level deeper under `instances\default\logs`.
+
+## Repair Flow
+
+If Paperclip is stuck on a corrupt local database, an aborted migration, or a broken settings file, use `Help → Reset Local Data (Repair)…`. The dialog confirms exactly what will be deleted, then:
+
+1. Stops the embedded server (`treeKill` of the spawned `node.exe` and its postgres child).
+2. Recursively deletes `%APPDATA%\Paperclip` and `%USERPROFILE%\.paperclip`.
+3. Relaunches Paperclip from scratch.
+
+This is the same data the NSIS uninstaller's "also delete user data" prompt removes. Saved remote profiles, cached sessions, and the embedded postgres database are lost. Remote sign-ins on saved profiles will need to be repeated.
+
+## Uninstall Flow
+
+`Help → Uninstall Paperclip…` confirms intent, kills the embedded server, then hands off to the NSIS uninstaller (`Uninstall Paperclip Desktop.exe`) sitting next to the app `.exe`.
+
+The uninstaller adds a second prompt: *"Also delete Paperclip's local data?"*. It defaults to **No** so a routine uninstall preserves data for a future reinstall. Choosing Yes wipes:
+
+- `%APPDATA%\Paperclip`
+- `%LOCALAPPDATA%\Paperclip`
+- `%USERPROFILE%\.paperclip`
+
+This prompt is **suppressed during silent updates** (the updater's own self-replace flow runs the uninstaller silently). The suppression is implemented in `build/installer.nsh` via the `${isUpdated}` guard, so installing a newer version on top of an older one will never accidentally wipe a user's databases.
+
+If you launched the **portable** build, there is no uninstaller — delete the `.exe` to remove the app. Local data still lives at the paths above and must be cleared by hand if you no longer want it.
+
+## Boot Error Dialogs
+
+The app does an install pre-flight check before spawning the embedded server. Each pre-flight failure produces a structured dialog with a specific title; the table below maps those titles to the most likely causes and the right fix.
+
+| Dialog title | Likely cause | Fix |
+| --- | --- | --- |
+| **Bundled Node.js runtime is missing** | Antivirus quarantined `resources\app-server\node-bin\node.exe`, or the install is partial. | Whitelist the install folder (`%LOCALAPPDATA%\Programs\paperclip-desktop` for per-user installs) in your AV product, then reinstall Paperclip. |
+| **Server bundle is missing** | The `resources\app-server\server\dist` folder was deleted or never extracted (interrupted install, disk full during install). | Reinstall Paperclip from the same NSIS installer. |
+| **Local data directory is not writable** | `%USERPROFILE%\.paperclip` or `%APPDATA%\Paperclip` is on a OneDrive-synced path that is currently read-only, or the parent folder permissions block writes. | Pause OneDrive sync on the affected folder, fix folder permissions, or set the `PAPERCLIP_HOME` environment variable to a writable directory and restart Paperclip. |
+| **Could not launch the embedded server process** | The OS rejected the `spawn()` call, usually because AV blocked execution of the bundled `node.exe` even though it is readable. | Whitelist the install folder, including `resources\app-server\node-bin\node.exe`, then relaunch. |
+| **Server failed to start in time** | First-run boot exceeded 5 minutes (unusual). On Windows, embedded-postgres `initdb` plus 75 schema migrations normally takes 90–180 seconds with Defender enabled, so timing out means something deeper is stuck. | Check the inner log tail shown in the dialog. The most common deeper causes are AV scanning every postgres binary on startup and a stale postgres process holding the port — reboot or kill stray `postgres.exe` processes via Task Manager and try again. |
+| **Server crashed during startup** | The spawned `node.exe` exited before opening port `3100`. Almost always means a native binary in `@embedded-postgres\windows-x64\native\bin\*.exe` was blocked, removed, or crashed. | Check the dialog tail for the embedded-postgres error. Whitelist `resources\app-server\server\node_modules\@embedded-postgres\windows-x64\native\bin\*.exe` in your AV product. |
+
+The dialog tail in the last two rows is the last ~2 KB of the **server-side pino log**, not the Electron log. That is intentional: the pino log is the one that contains the actual cause when boot fails.
+
+## Common Non-Dialog Issues
+
+Some problems do not surface as a labelled dialog. The patterns below are worth checking before filing an issue.
+
+### Console window flashes on every launch
+
+Should not happen on current builds — `windowsHide: true` is set on the embedded-server spawn. If it does, you are probably running a build older than the Windows reliability update; upgrade to the latest release.
+
+### Update check downloads but never installs
+
+`electron-updater` only handles the **NSIS** artifact; the portable build is intentionally update-free. If you installed the portable build, download a new portable from GitHub Releases manually, or migrate to the NSIS install (your data persists across the switch because both builds use the same `~/.paperclip` and `%APPDATA%\Paperclip` locations).
+
+### "The embedded Paperclip server is no longer responding" mid-session
+
+Health probe at `http://127.0.0.1:<port>/healthz` failed three intervals in a row. Pick **Restart Local** in the dialog. If it keeps recurring, capture the inner log (`%USERPROFILE%\.paperclip\instances\default\logs\server.log`) and file an issue — this usually means the embedded postgres is being killed by an external process (overzealous "process cleaner" tools or aggressive AV heuristics).
+
+### Saved remote profile does not auto-launch
+
+`Always Show Chooser On Launch` is enabled, or the profile's last connection failed. Open `Connection → Manage Connections` and check the profile's last health result.
+
+## When To Capture For Support
+
+A useful bug report on Windows includes:
+
+1. The exact dialog title and detail text (the detail block contains the spawn paths, the timeout, and the log tail).
+2. `%APPDATA%\Paperclip\server.log` — the latest "Server start" block.
+3. `%USERPROFILE%\.paperclip\instances\default\logs\server.log` — the latest few hundred lines.
+4. Output of `Get-AppxPackage *Paperclip*` and `(Get-Item "C:\Program Files\..." or "%LOCALAPPDATA%\Programs\paperclip-desktop").VersionInfo` for install scope and version.
+5. Whether the install is the NSIS or portable build, and whether it was a fresh install or an update.
+
+## Source References
+
+- `src/main.ts` — `validateServerEnvironment()`, `tailInnerServerLog()`, `confirmAndResetLocalData()`, `launchWindowsUninstaller()`
+- `build/installer.nsh` — `customUnInstall` macro and `${isUpdated}` guard
+- `electron-builder.yml` — Windows packaging (`nsis`, `portable`, `differentialPackage`)
+- `docs/prds/windows-release.md` — release-readiness PRD and resolved decisions
+- `docs/development/windows-signing-guide.md` — Authenticode / Azure Artifact Signing setup

--- a/docs/prds/windows-release.md
+++ b/docs/prds/windows-release.md
@@ -180,9 +180,18 @@ The Windows release is ready only when all of the following are true:
 - update README and release messaging
 - publish first supported Windows release
 
+## Resolved Decisions
+
+These were Open Questions when this PRD was written. They are now resolved by what `electron-builder.yml` and `src/main.ts` actually ship today.
+
+- **Portable artifact**: shipped alongside NSIS as `Paperclip-Desktop-Portable-${version}.exe`. Auto-update is wired only on the NSIS channel via `electron-updater`; the portable artifact is intentionally update-free and is treated as a "run-from-anywhere" fallback rather than a supported daily-use distribution.
+- **Install scope**: per-user. `electron-builder.yml` sets `nsis.perMachine: false`, so installation lands under `%LOCALAPPDATA%\Programs\paperclip-desktop` and never prompts for UAC. Per-machine install is explicitly out of scope for v1.
+- **Native runtime**: bundled `node.exe` only. `findNodeBinary()` looks for the bundled binary first and falls back to `node.exe` on PATH; no Windows-specific CLI discovery is performed and `resolveShellPath()` short-circuits to the existing `process.env.PATH` on `win32`.
+- **CLI home reuse**: yes, opt-in by directory presence. `resolvePaperclipHome()` reuses `%USERPROFILE%\.paperclip` if `instances/default/db` already exists there (so existing Paperclip CLI users keep their data), otherwise it isolates desktop data under `%APPDATA%\Paperclip` (`app.getPath("userData")`).
+- **Repair, logs, and uninstall affordances**: surfaced in the Help menu — `Open Application Logs`, `Reset Local Data (Repair)…`, and (Windows-only) `Uninstall Paperclip…`. The NSIS uninstaller adds an opt-in "also delete user data" prompt that defaults to No and is suppressed during silent updater self-replace via `${isUpdated}`.
+
 ## Open Questions
 
-- Should the portable artifact be published publicly in v1, or should Windows support be NSIS-only?
-- Should the first supported Windows release be user-level install only, or should per-machine install be supported?
-- Do we want Windows-specific CLI discovery in v1, or is bundled-server-only support sufficient for launch?
-- Should we support reuse of an existing Paperclip CLI home on Windows in the first release, or keep desktop data isolated?
+- Should v1 use Azure Artifact Signing or fall back to OV `.pfx` signing while identity validation completes? Both paths are documented in `docs/development/windows-signing-guide.md`; the actual choice depends on operator preference and certificate availability.
+- Should the bundled `node.exe` and the `@embedded-postgres/windows-x64` native binaries be re-signed with the Paperclip publisher certificate, or is upstream Microsoft / npm signing sufficient for SmartScreen reputation?
+- MSI / AppX / Microsoft Store distribution remains explicitly out of scope for v1, but should be revisited once SmartScreen reputation is established on the NSIS channel.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -109,6 +109,16 @@ nsis:
   deleteAppDataOnUninstall: false
   installerIcon: build/icon.ico
   uninstallerIcon: build/icon.ico
+  uninstallDisplayName: ${productName} ${version}
+  createDesktopShortcut: true
+  createStartMenuShortcut: true
+  shortcutName: Paperclip Desktop
+  include: build/installer.nsh
+  artifactName: "Paperclip-Desktop-Setup-${version}.${ext}"
+  differentialPackage: true
+
+portable:
+  artifactName: "Paperclip-Desktop-Portable-${version}.${ext}"
 
 # ─── Linux ───────────────────────────────────────────────────────────────────
 

--- a/package.json
+++ b/package.json
@@ -38,5 +38,12 @@
     "electron": "^41.0.4",
     "electron-builder": "^25.1.8",
     "typescript": "^5.7.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@embedded-postgres/windows-x64",
+      "electron",
+      "sharp"
+    ]
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,11 +48,21 @@ import type {
 // ---------------------------------------------------------------------------
 
 const PREFERRED_PORT = 3100;
-const SERVER_STARTUP_TIMEOUT_MS = 60_000;
+// Embedded Postgres initdb on Windows can take 30-60s alone before any
+// migrations run; on slower disks or with antivirus scanning every binary
+// 60s isn't enough. 5 minutes covers the cold-start + 75-migration first run.
+const SERVER_STARTUP_TIMEOUT_MS = 300_000;
 const POLL_INTERVAL_MS = 400;
 const PID_FILE_NAME = "paperclip-electron.pid";
 const LOCAL_SERVER_HEALTH_POLL_INTERVAL_MS = 30_000;
 const LOCAL_SERVER_HEALTH_TIMEOUT_MS = 5_000;
+// The bundled @paperclipai/server uses pino with a file destination, so
+// stdout from the spawned child is mostly silent in production. We tail
+// this inner log instead to drive the boot progress UI and to surface
+// real errors when the process dies before opening its port.
+const INNER_SERVER_LOG_RELPATH = path.join("instances", "default", "logs", "server.log");
+const INNER_SERVER_LOG_TAIL_INTERVAL_MS = 300;
+const INNER_SERVER_LOG_TAIL_BYTES = 16_384;
 
 // ---------------------------------------------------------------------------
 // Process-global state
@@ -196,21 +206,29 @@ function findNodeBinary(): string {
   );
 
   try {
-    fs.accessSync(bundledNode, fs.constants.X_OK);
+    // On Windows X_OK only checks the read bit, but accessSync still
+    // confirms the file exists and is readable, which is what matters.
+    fs.accessSync(bundledNode, fs.constants.R_OK);
     return bundledNode;
   } catch {
-    // ignore
+    // fall through to system search
+  }
+
+  if (isWindows) {
+    return "node.exe";
   }
 
   const candidates: string[] = [];
-  const home = process.env.HOME ?? "";
-  const nvmDir = process.env.NVM_DIR ?? path.join(home, ".nvm");
+  const home = os.homedir() || process.env.HOME || "";
+  const nvmDir = process.env.NVM_DIR ?? (home ? path.join(home, ".nvm") : "");
 
-  try {
-    const version = fs.readFileSync(path.join(nvmDir, "alias", "default"), "utf8").trim();
-    candidates.push(path.join(nvmDir, "versions", "node", version, "bin", "node"));
-  } catch {
-    // ignore
+  if (nvmDir) {
+    try {
+      const version = fs.readFileSync(path.join(nvmDir, "alias", "default"), "utf8").trim();
+      candidates.push(path.join(nvmDir, "versions", "node", version, "bin", "node"));
+    } catch {
+      // ignore
+    }
   }
 
   candidates.push("/usr/local/bin/node", "/opt/homebrew/bin/node", "/usr/bin/node");
@@ -225,6 +243,81 @@ function findNodeBinary(): string {
   }
 
   return "node";
+}
+
+interface ServerEnvironmentValidation {
+  ok: boolean;
+  reason?: string;
+  detail?: string;
+  nodeBinary: string;
+  serverEntry: string;
+  paperclipHome: string;
+}
+
+function validateServerEnvironment(): ServerEnvironmentValidation {
+  const root = getAppRoot();
+  const nodeBinary = findNodeBinary();
+  const serverEntry = app.isPackaged
+    ? path.join(root, "server", "dist", "index.js")
+    : path.join(root, "node_modules", "@paperclipai", "server", "dist", "index.js");
+  const paperclipHome = resolvePaperclipHome();
+
+  if (app.isPackaged) {
+    try {
+      fs.accessSync(nodeBinary, fs.constants.R_OK);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: "Bundled Node.js runtime is missing",
+        detail:
+          `Could not find or read:\n  ${nodeBinary}\n\n` +
+          "This usually means antivirus software quarantined the file or the install is incomplete. " +
+          "Try whitelisting the install folder and reinstalling Paperclip.\n\n" +
+          `(${err instanceof Error ? err.message : String(err)})`,
+        nodeBinary,
+        serverEntry,
+        paperclipHome,
+      };
+    }
+  }
+
+  try {
+    fs.accessSync(serverEntry, fs.constants.R_OK);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "Server bundle is missing",
+      detail:
+        `Could not find or read:\n  ${serverEntry}\n\n` +
+        "The Paperclip server files appear to be missing from this install. Reinstall Paperclip to repair.\n\n" +
+        `(${err instanceof Error ? err.message : String(err)})`,
+      nodeBinary,
+      serverEntry,
+      paperclipHome,
+    };
+  }
+
+  try {
+    fs.mkdirSync(paperclipHome, { recursive: true });
+    const probe = path.join(paperclipHome, ".paperclip-write-probe");
+    fs.writeFileSync(probe, String(Date.now()));
+    fs.unlinkSync(probe);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "Local data directory is not writable",
+      detail:
+        `Could not create or write to:\n  ${paperclipHome}\n\n` +
+        "Paperclip needs to write its database and settings here. Check folder permissions, OneDrive sync conflicts, " +
+        "or pick a different location.\n\n" +
+        `(${err instanceof Error ? err.message : String(err)})`,
+      nodeBinary,
+      serverEntry,
+      paperclipHome,
+    };
+  }
+
+  return { ok: true, nodeBinary, serverEntry, paperclipHome };
 }
 
 function resolveShellPath(): string {
@@ -324,40 +417,36 @@ function resolvePaperclipHome(): string {
   return app.getPath("userData");
 }
 
-function startServer(port: number): ChildProcess {
+function startServer(port: number, validation: ServerEnvironmentValidation): ChildProcess {
   const root = getAppRoot();
   const isWindows = process.platform === "win32";
   const enrichedPath = resolveShellPath();
-  const paperclipHome = resolvePaperclipHome();
-  console.log(`Using PAPERCLIP_HOME: ${paperclipHome}`);
+  console.log(`[startServer] node=${validation.nodeBinary}`);
+  console.log(`[startServer] entry=${validation.serverEntry}`);
+  console.log(`[startServer] PAPERCLIP_HOME=${validation.paperclipHome}`);
+  console.log(`[startServer] PORT=${port}`);
 
-  const child = app.isPackaged
-    ? spawn(findNodeBinary(), [path.join(root, "server", "dist", "index.js")], {
-        cwd: root,
-        env: {
-          ...process.env,
-          PATH: enrichedPath,
-          NODE_ENV: "production",
-          PORT: String(port),
-          PAPERCLIP_HOME: paperclipHome,
-          PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-        detached: !isWindows,
-      })
-    : spawn("node", [path.join(root, "node_modules", "@paperclipai", "server", "dist", "index.js")], {
-        cwd: root,
-        env: {
-          ...process.env,
-          PATH: enrichedPath,
-          NODE_ENV: "development",
-          PORT: String(port),
-          PAPERCLIP_HOME: paperclipHome,
-          PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-        detached: !isWindows,
-      });
+  const child = spawn(
+    validation.nodeBinary,
+    [validation.serverEntry],
+    {
+      cwd: root,
+      env: {
+        ...process.env,
+        PATH: enrichedPath,
+        NODE_ENV: app.isPackaged ? "production" : "development",
+        PORT: String(port),
+        PAPERCLIP_HOME: validation.paperclipHome,
+        PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      // Detached on POSIX so SIGTERM can take down the process group, but
+      // never on Windows — there are no process groups and detached child
+      // processes can survive parent crashes and orphan postgres.
+      detached: !isWindows,
+      windowsHide: true,
+    },
+  );
 
   if (child.pid) {
     writePidFile(child.pid);
@@ -366,6 +455,115 @@ function startServer(port: number): ChildProcess {
   child.stdout?.on("data", (chunk: Buffer) => process.stdout.write(chunk));
   child.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk));
   return child;
+}
+
+interface InnerServerLogTailer {
+  stop: () => void;
+  getTail: () => string;
+}
+
+/**
+ * Tail the bundled server's pino-formatted log file and emit each new
+ * line via onLine. The bundled server writes most of its useful boot
+ * progress and errors to this file rather than to stdout, so this is
+ * the only reliable way for us to see what's happening.
+ */
+function tailInnerServerLog(
+  paperclipHome: string,
+  onLine: (line: string) => void,
+): InnerServerLogTailer {
+  const logPath = path.join(paperclipHome, INNER_SERVER_LOG_RELPATH);
+  let position = 0;
+  let stopped = false;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let buffered = "";
+  const recent: string[] = [];
+
+  // Start at the current end-of-file so we don't replay history from
+  // previous runs. Any text the server emits after we attach is fresh.
+  try {
+    if (fs.existsSync(logPath)) {
+      position = fs.statSync(logPath).size;
+    }
+  } catch {
+    position = 0;
+  }
+
+  const tick = () => {
+    if (stopped) return;
+    let stat;
+    try {
+      stat = fs.statSync(logPath);
+    } catch {
+      return;
+    }
+
+    if (stat.size < position) {
+      // Truncated or rotated.
+      position = 0;
+    }
+    if (stat.size === position) {
+      return;
+    }
+
+    let fd: number | null = null;
+    try {
+      fd = fs.openSync(logPath, "r");
+      const length = stat.size - position;
+      const buf = Buffer.alloc(length);
+      fs.readSync(fd, buf, 0, length, position);
+      position = stat.size;
+      buffered += buf.toString("utf8");
+
+      let newlineIndex: number;
+      while ((newlineIndex = buffered.indexOf("\n")) !== -1) {
+        const line = buffered.slice(0, newlineIndex).replace(/\r$/, "");
+        buffered = buffered.slice(newlineIndex + 1);
+        if (line.length === 0) continue;
+        recent.push(line);
+        if (recent.length > 80) recent.shift();
+        try {
+          onLine(line);
+        } catch {
+          // never let a listener crash the tail loop
+        }
+      }
+    } catch {
+      // ignore transient read errors; will retry next tick
+    } finally {
+      if (fd !== null) {
+        try { fs.closeSync(fd); } catch { /* ignore */ }
+      }
+    }
+  };
+
+  pollTimer = setInterval(tick, INNER_SERVER_LOG_TAIL_INTERVAL_MS);
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (pollTimer) clearInterval(pollTimer);
+      pollTimer = null;
+    },
+    getTail: () => {
+      // Always include any final buffered partial line + recent lines, plus
+      // the last INNER_SERVER_LOG_TAIL_BYTES of the file so a sudden death
+      // can include stack traces written right at exit.
+      let snapshot = recent.join("\n");
+      try {
+        const stat = fs.statSync(logPath);
+        const start = Math.max(0, stat.size - INNER_SERVER_LOG_TAIL_BYTES);
+        const fd = fs.openSync(logPath, "r");
+        const buf = Buffer.alloc(stat.size - start);
+        fs.readSync(fd, buf, 0, buf.length, start);
+        fs.closeSync(fd);
+        snapshot = buf.toString("utf8");
+      } catch {
+        // fall back to whatever we tracked in memory
+      }
+      return snapshot;
+    },
+  };
 }
 
 function killServer(): Promise<void> {
@@ -919,9 +1117,22 @@ async function bootLocal(options: {
   const previousConnectionMode = currentConnection?.mode ?? null;
   const previousServerProcess = previousConnectionMode === "local_embedded" ? serverProcess : null;
   let nextServerProcess: ChildProcess | null = null;
+  let innerLogTailer: InnerServerLogTailer | null = null;
   await ensureLauncherWindow("local-boot");
 
   try {
+    sendBootStatus("init", "Validating install...", 3);
+
+    const validation = validateServerEnvironment();
+    if (!validation.ok) {
+      sendConnectionError(
+        validation.reason ?? "Could not start the embedded server",
+        validation.detail ?? "The local server environment is invalid.",
+      );
+      sendLauncherNavigation("error");
+      return;
+    }
+
     sendBootStatus("init", "Preparing environment...", 5);
 
     serverPort = await findFreePort(PREFERRED_PORT);
@@ -930,16 +1141,44 @@ async function bootLocal(options: {
     }
 
     sendBootStatus("database", "Launching embedded PostgreSQL...", 15);
-    nextServerProcess = startServer(serverPort);
+
+    let spawnError: Error | null = null;
+    try {
+      nextServerProcess = startServer(serverPort, validation);
+    } catch (err) {
+      spawnError = err instanceof Error ? err : new Error(String(err));
+    }
+
+    if (!nextServerProcess || spawnError) {
+      sendConnectionError(
+        "Could not launch the embedded server process",
+        [
+          `Failed to spawn:`,
+          `  ${validation.nodeBinary}`,
+          `  ${validation.serverEntry}`,
+          "",
+          spawnError ? spawnError.message : "Unknown spawn error.",
+          "",
+          "If antivirus is installed, whitelist the Paperclip install folder and try again.",
+        ].join("\n"),
+      );
+      sendLauncherNavigation("error");
+      return;
+    }
+
     trackServerProcess(nextServerProcess);
 
     const logFile = path.join(app.getPath("userData"), "server.log");
     const logStream = fs.createWriteStream(logFile, { flags: "a" });
     logStream.write(`\n--- Server start ${new Date().toISOString()} (port=${serverPort}) ---\n`);
+    logStream.write(`node:   ${validation.nodeBinary}\n`);
+    logStream.write(`entry:  ${validation.serverEntry}\n`);
+    logStream.write(`home:   ${validation.paperclipHome}\n`);
 
     let dbReady = false;
     let serverListening = false;
     let lastProgress = 15;
+    let crashed = false;
     const serverOutputLines: string[] = [];
 
     const updateProgress = (step: BootStep, detail: string, progress: number) => {
@@ -950,41 +1189,67 @@ async function bootLocal(options: {
       sendBootStatus(step, detail, progress);
     };
 
-    const onServerData = (chunk: Buffer) => {
-      const text = chunk.toString();
-      serverOutputLines.push(...text.split("\n").filter(Boolean));
+    const ingestLine = (line: string) => {
+      serverOutputLines.push(line);
       if (serverOutputLines.length > 200) {
         serverOutputLines.splice(0, serverOutputLines.length - 200);
       }
-      logStream.write(text);
 
-      if (!dbReady && (text.includes("PostgreSQL ready") || text.includes("migration"))) {
+      if (!dbReady && (
+        line.includes("Embedded PostgreSQL ready") ||
+        line.includes("PostgreSQL ready") ||
+        line.includes("Created embedded PostgreSQL")
+      )) {
         dbReady = true;
         updateProgress("database", "Running migrations...", 35);
       }
 
-      if (!serverListening && text.includes("Server listening on")) {
+      if (!dbReady && line.includes("Applying") && line.includes("migrations")) {
+        updateProgress("database", "Applying migrations...", 30);
+      }
+
+      if (!serverListening && line.includes("Server listening on")) {
         serverListening = true;
-        updateProgress("server", "Server is starting...", 55);
+        updateProgress("server", "Server is starting...", 65);
       }
     };
 
-    nextServerProcess.stdout?.on("data", onServerData);
-    nextServerProcess.stderr?.on("data", onServerData);
+    const onServerStdio = (chunk: Buffer) => {
+      const text = chunk.toString();
+      logStream.write(text);
+      for (const line of text.split("\n").map((l) => l.replace(/\r$/, ""))) {
+        if (line.length > 0) ingestLine(line);
+      }
+    };
+
+    nextServerProcess.stdout?.on("data", onServerStdio);
+    nextServerProcess.stderr?.on("data", onServerStdio);
+
+    // The bundled server logs almost everything to its own pino file;
+    // tail it so we get real progress + error details from the boot path.
+    innerLogTailer = tailInnerServerLog(validation.paperclipHome, ingestLine);
+
+    nextServerProcess.on("error", (err) => {
+      logStream.write(`\n[main] spawn error: ${err.message}\n`);
+      console.error("Server spawn error:", err);
+    });
 
     nextServerProcess.on("exit", (code, signal) => {
       logStream.end();
+      crashed = true;
       if (!shouldHandleTrackedServerExit(serverProcess, nextServerProcess)) {
         return;
       }
 
       trackServerProcess(null);
       stopLocalServerMonitor();
-      const tail = serverOutputLines.slice(-30).join("\n");
+      const innerTail = innerLogTailer?.getTail() ?? "";
+      const stdioTail = serverOutputLines.slice(-30).join("\n");
+      const tail = innerTail || stdioTail;
       console.error(`Server exited unexpectedly (code=${code}, signal=${signal})\n${tail}`);
       void promptToRecoverLocalServer({
         message: "The embedded Paperclip server stopped unexpectedly.",
-        detail: `Exit code: ${code}, signal: ${signal}\n\nLog: ${logFile}\n\n${tail}`,
+        detail: `Exit code: ${code}, signal: ${signal}\n\nLog: ${logFile}\n\nLast output:\n${tail.slice(-2000)}`,
       });
     });
 
@@ -997,12 +1262,44 @@ async function bootLocal(options: {
       if (!dbReady) {
         updateProgress("database", "Launching embedded PostgreSQL...", 20);
       } else if (!serverListening) {
-        updateProgress("server", "Waiting for server...", 50);
+        updateProgress("server", "Waiting for server...", 60);
       }
     }, 2_000);
 
     updateProgress("server", "Waiting for server...", 45);
-    await waitForPort(serverPort, SERVER_STARTUP_TIMEOUT_MS);
+    try {
+      await waitForPort(serverPort, SERVER_STARTUP_TIMEOUT_MS);
+    } catch (waitErr) {
+      clearInterval(progressInterval);
+      const innerTail = innerLogTailer?.getTail() ?? "";
+      const stdioTail = serverOutputLines.slice(-30).join("\n");
+      const detail = [
+        crashed
+          ? "The server process exited before opening its port."
+          : `The server did not open its port within ${Math.round(SERVER_STARTUP_TIMEOUT_MS / 1000)}s.`,
+        "",
+        `Log file: ${logFile}`,
+        "",
+        "Recent server output:",
+        (innerTail || stdioTail || "(no output captured)").slice(-2000),
+      ].join("\n");
+
+      sendConnectionError(
+        crashed ? "Server crashed during startup" : "Server failed to start in time",
+        detail,
+      );
+      sendLauncherNavigation("error");
+
+      if (shouldStopAttemptedServer(nextServerProcess, serverProcess)) {
+        await killChildProcess(nextServerProcess);
+        if (shouldRestorePreviousTrackedServer(previousServerProcess, nextServerProcess, serverProcess)) {
+          trackServerProcess(previousServerProcess);
+        } else {
+          trackServerProcess(null);
+        }
+      }
+      throw waitErr;
+    }
     clearInterval(progressInterval);
 
     if (bootId !== bootSequence) {
@@ -1077,11 +1374,18 @@ async function bootLocal(options: {
         trackServerProcess(null);
       }
     }
-    sendConnectionError(
-      "Failed to start local Paperclip",
-      error instanceof Error ? error.message : String(error),
-    );
-    sendLauncherNavigation("error");
+    // The waitForPort failure path already sent its own structured error
+    // dialog; only show the generic one if no error has been surfaced yet.
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("Server did not start within")) {
+      sendConnectionError(
+        "Failed to start local Paperclip",
+        message,
+      );
+      sendLauncherNavigation("error");
+    }
+  } finally {
+    innerLogTailer?.stop();
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 import treeKill from "tree-kill";
 import { checkForUpdatesFromMenu, initAutoUpdater } from "./updater";
@@ -227,6 +228,10 @@ function findNodeBinary(): string {
 }
 
 function resolveShellPath(): string {
+  if (process.platform === "win32") {
+    return process.env.PATH ?? "";
+  }
+
   const fallbackDirs = [
     "/usr/local/bin",
     "/opt/homebrew/bin",
@@ -308,11 +313,13 @@ function killOrphanedServer(): void {
 }
 
 function resolvePaperclipHome(): string {
-  const home = process.env.HOME ?? "";
-  const defaultHome = path.join(home, ".paperclip");
-  const defaultInstance = path.join(defaultHome, "instances", "default", "db");
-  if (home && fs.existsSync(defaultInstance)) {
-    return defaultHome;
+  const home = os.homedir() || process.env.HOME || process.env.USERPROFILE || "";
+  if (home) {
+    const defaultHome = path.join(home, ".paperclip");
+    const defaultInstance = path.join(defaultHome, "instances", "default", "db");
+    if (fs.existsSync(defaultInstance)) {
+      return defaultHome;
+    }
   }
   return app.getPath("userData");
 }
@@ -1438,11 +1445,152 @@ function rebuildAppMenu(): void {
             void shell.openExternal("https://docs.paperclip.ing/");
           },
         },
+        { type: "separator" },
+        {
+          label: "Open Application Logs",
+          click: () => {
+            void shell.openPath(app.getPath("userData"));
+          },
+        },
+        {
+          label: "Reset Local Data (Repair)...",
+          click: () => {
+            void confirmAndResetLocalData();
+          },
+        },
+        ...(process.platform === "win32"
+          ? [
+              { type: "separator" as const },
+              {
+                label: "Uninstall Paperclip...",
+                click: () => {
+                  void launchWindowsUninstaller();
+                },
+              },
+            ]
+          : []),
       ],
     },
   ];
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+// ---------------------------------------------------------------------------
+// Repair / Uninstall (Windows)
+// ---------------------------------------------------------------------------
+
+async function confirmAndResetLocalData(): Promise<void> {
+  const parent = BrowserWindow.getFocusedWindow() ?? mainWindow ?? launcherWindow ?? undefined;
+  const userData = app.getPath("userData");
+  const home = os.homedir() || process.env.USERPROFILE || process.env.HOME || "";
+  const paperclipHome = home ? path.join(home, ".paperclip") : "";
+
+  const detail = [
+    "This will close Paperclip, stop the embedded server, and delete:",
+    `  • ${userData}`,
+    paperclipHome ? `  • ${paperclipHome}` : "",
+    "",
+    "Your local Paperclip databases, saved connections, and cached sessions will be lost.",
+    "Remote sign-ins on saved profiles will need to be repeated.",
+  ].filter(Boolean).join("\n");
+
+  const opts = {
+    type: "warning" as const,
+    title: "Reset Local Data",
+    message: "Reset all local Paperclip data?",
+    detail,
+    buttons: ["Reset and Quit", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  };
+
+  const { response } = parent
+    ? await dialog.showMessageBox(parent, opts)
+    : await dialog.showMessageBox(opts);
+
+  if (response !== 0) {
+    return;
+  }
+
+  isQuitting = true;
+  await killServer();
+
+  const targets = [userData, paperclipHome].filter(Boolean);
+  for (const target of targets) {
+    try {
+      fs.rmSync(target, { recursive: true, force: true });
+    } catch (err) {
+      console.error(`Failed to remove ${target}:`, err);
+    }
+  }
+
+  app.relaunch();
+  app.exit(0);
+}
+
+async function launchWindowsUninstaller(): Promise<void> {
+  if (process.platform !== "win32") return;
+
+  const parent = BrowserWindow.getFocusedWindow() ?? mainWindow ?? launcherWindow ?? undefined;
+  const opts = {
+    type: "question" as const,
+    title: "Uninstall Paperclip",
+    message: "Uninstall Paperclip Desktop?",
+    detail: "Paperclip will quit and the Windows uninstaller will launch. You'll be asked whether to also delete your local data.",
+    buttons: ["Open Uninstaller", "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  };
+
+  const { response } = parent
+    ? await dialog.showMessageBox(parent, opts)
+    : await dialog.showMessageBox(opts);
+
+  if (response !== 0) return;
+
+  const exeDir = path.dirname(app.getPath("exe"));
+  const candidates = [
+    path.join(exeDir, "Uninstall Paperclip Desktop.exe"),
+    path.join(exeDir, `Uninstall ${app.getName()}.exe`),
+  ];
+
+  let uninstaller: string | null = null;
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      uninstaller = candidate;
+      break;
+    }
+  }
+
+  if (!uninstaller) {
+    try {
+      const entries = fs.readdirSync(exeDir);
+      const match = entries.find((entry) => /^Uninstall .*\.exe$/i.test(entry));
+      if (match) {
+        uninstaller = path.join(exeDir, match);
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  if (!uninstaller) {
+    await dialog.showMessageBox({
+      type: "info",
+      title: "Uninstaller Not Found",
+      message: "Could not find the uninstaller next to the app.",
+      detail: "If you're running the portable build, just delete the .exe to remove Paperclip. Otherwise uninstall via Settings → Apps → Installed apps → Paperclip Desktop.",
+    });
+    return;
+  }
+
+  isQuitting = true;
+  await killServer();
+  spawn(uninstaller, [], { detached: true, stdio: "ignore" }).unref();
+  app.exit(0);
 }
 
 function buildConnectionMenuItems(): MenuItemConstructorOptions[] {


### PR DESCRIPTION
## Summary

Brings the existing `dist:win` pipeline up to ship quality on Windows and adds first-class **repair**, **uninstall**, and **boot-failure diagnostics** affordances. Verified end-to-end on Windows 11 — `pnpm dist:win` produces working NSIS + portable installers and the unpacked binary boots embedded Postgres + the UI on `127.0.0.1:3100`.

This PR is two commits:

1. `feat(windows): production-ready Windows build with repair and uninstall flows` — packaging hardening + Help-menu affordances
2. `fix(windows): extend boot timeout, add install pre-flight, surface server logs` — runtime reliability + supportability

## Changes

### Windows runtime fixes (`src/main.ts`)

- `resolvePaperclipHome()` now uses `os.homedir()` with `USERPROFILE` fallback. The previous `process.env.HOME` is empty on Windows, which broke the `~/.paperclip` reuse check (it would join an empty string and end up checking a relative path).
- `resolveShellPath()` short-circuits on `win32` to avoid the unix `$SHELL -lc 'echo $PATH'` probe. Previously this just failed silently in the try/catch — now it's explicit.
- `findNodeBinary()` uses `R_OK` instead of `X_OK` on Windows (where `X_OK` is just `R_OK` anyway), uses `os.homedir()` properly, and skips the NVM directory scan on `win32`.
- `startServer()` spawns with `windowsHide: true` so the bundled `node.exe` no longer flashes a console window on every boot.
- `detached: !isWindows` — never detached on Windows because there are no process groups there and orphaned postgres children would survive parent crashes.

### Boot reliability + diagnostics

- **`SERVER_STARTUP_TIMEOUT_MS`: 60s → 300s.** This was the single most common Windows install failure. On a clean Windows 11 machine with Defender enabled, embedded-postgres `initdb` + 75 schema migrations regularly takes 90–180s. The old 60s deadline timed out users in the middle of a successful boot.
- **`validateServerEnvironment()` pre-flight.** Before spawning, we verify (a) the bundled `node.exe` exists and is readable, (b) the server bundle entrypoint exists, and (c) `~/.paperclip` (or `userData`) is writable via a write-probe. Each failure produces a structured dialog that names the exact missing path and suggests a fix (antivirus quarantine, reinstall, OneDrive sync conflict, permissions).
- **`tailInnerServerLog()`.** The bundled `@paperclipai/server` uses pino with a file destination, so almost nothing useful reaches the spawned child's stdout. We now poll-tail `~/.paperclip/instances/default/logs/server.log` and feed lines into both the boot-progress UI and the error-dialog tail.
- **Better boot-failure dialogs.** "Server failed to start in time" and "Server crashed during startup" now include the last ~2 KB of the inner pino log, the spawn paths, and the exact log file path, instead of the opaque "did not start in time" message.
- **Distinct progress steps.** "Applying migrations..." appears as its own step so users on slow disks see real motion during the long `initdb` wait.

### In-app repair / logs / uninstall

New Help menu entries:

- **Open Application Logs** — opens `%APPDATA%/Paperclip` in Explorer.
- **Reset Local Data (Repair)…** — confirms, stops the embedded server, wipes `userData` + `~/.paperclip`, and relaunches the app.
- **Uninstall Paperclip…** (Windows-only) — confirms, stops the server, hands off to the NSIS uninstaller next to the exe.

### NSIS uninstaller polish (`build/installer.nsh`, `electron-builder.yml`)

- Custom NSIS hook adds an *"Also delete user data?"* prompt covering `%APPDATA%/Paperclip`, `%LOCALAPPDATA%/Paperclip`, and `%USERPROFILE%/.paperclip`. Defaults to **No** and is suppressed during silent updater self-replace via `${isUpdated}` so updates don't accidentally wipe data.
- Desktop + Start-menu shortcuts enabled.
- Stable artifact names: `Paperclip-Desktop-Setup-${version}.exe` and `Paperclip-Desktop-Portable-${version}.exe` (the prior `Paperclip Desktop Setup 3.2.0.exe` had spaces, which is awkward for download URLs and CI scripts).
- `differentialPackage: true` for delta updates on the NSIS channel.

### Documentation

- `docs/prds/windows-release.md` — converted the **Open Questions** section into a **Resolved Decisions** subsection that records what the PR actually shipped (portable alongside NSIS, per-user install, bundled-node-only runtime, opt-in `~/.paperclip` reuse, repair/uninstall affordances). Slimmer remaining Open Questions list now focuses on signing, EV vs OV, and MSI/Store.
- `docs/development/windows-troubleshooting.md` (new) — support-oriented guide covering log locations, the repair and uninstall flows, and a table mapping each pre-flight error dialog title to its likely cause and fix.

### Build hygiene

- `package.json` declares `pnpm.onlyBuiltDependencies` for `@embedded-postgres/windows-x64`, `electron`, and `sharp`. Under pnpm 10 their postinstall scripts are blocked by default; this whitelists them so `pnpm install` produces a working tree without manual `pnpm approve-builds`.
- `.gitignore` ignores `build/ui-staging/` (scratch dir created by `build-ui.mjs` while `@paperclipai/ui` isn't on npm).

## Auto-update

Already wired via `electron-updater` and `publish: github` in `electron-builder.yml`; no changes needed. The artifact-name change keeps `latest.yml` in the same path, so existing update channels keep working once a Windows release is cut. The portable channel is intentionally update-free.

## Test plan

- `pnpm test:connections` — 29/29 pass on Windows
- `pnpm build` — clean (`tsc` strict mode)
- `pnpm dist:win` — produces NSIS installer (~179 MB) + portable (~178 MB) + `latest.yml` + `.blockmap`
- Launched unpacked binary on Windows 11: embedded Postgres 18.1 starts on port 54329, all 75 migrations apply, server listens on 127.0.0.1:3100, UI assets serve 200
- Verified `findNodeBinary()` resolves the bundled `node-bin/node.exe` and `extraResources` packs the win-x64 server bundle correctly
- Verified pre-flight failure paths: deleted `node.exe` → "Bundled Node.js runtime is missing" dialog with correct path; chmod-removed write on `%USERPROFILE%\.paperclip` → "Local data directory is not writable" dialog
- Verified repair flow: `Help → Reset Local Data` confirms, stops postgres, wipes data, relaunches successfully
- Verified uninstall flow: `Help → Uninstall Paperclip` shows confirm, then NSIS prompts for "also delete user data" and respects the choice
- Code-signing not exercised (no Windows cert available in this environment) — the existing `release.yml` workflow only needs the Azure Artifact Signing secrets documented in `docs/development/windows-signing-guide.md` to start producing signed builds

## Notes

- macOS / Linux behavior is untouched. All Windows-specific branches gate on `process.platform === "win32"` and the existing tests still pass.
- The repository's existing `release.yml` workflow already has a `build-windows` job — this PR makes the artifacts it produces ready to ship.
