### PR TITLE
Fix remote preflight for redacted authenticated health

### DIFF
--- a/src/connection/preflight.ts
+++ b/src/connection/preflight.ts
@@ -24,6 +24,16 @@ interface HealthPayload {
   bootstrapInviteActive?: unknown;
 }
 
+interface ParsedHealthPayload {
+  status: string;
+  version: string | null;
+  deploymentMode: DeploymentMode;
+  deploymentExposure: DeploymentExposure | null;
+  authReady: boolean | null;
+  bootstrapStatus: BootstrapStatus | null;
+  bootstrapInviteActive: boolean | null;
+}
+
 export async function preflightRemoteConnection(options: PreflightOptions): Promise<RemotePreflightResult> {
   const fetchImpl = options.fetchImpl ?? fetch;
   const timeoutMs = options.timeoutMs ?? 8_000;
@@ -42,7 +52,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
 
   try {
     const healthResponse = await fetchJson(fetchImpl, new URL("/api/health", normalized.origin), timeoutMs);
-    const health = parseHealthPayload(healthResponse.body);
+    const health = healthResponse.status === 200 ? parseHealthPayload(healthResponse.body) : null;
 
     if (!health) {
       return buildFailure({
@@ -117,7 +127,7 @@ export async function preflightRemoteConnection(options: PreflightOptions): Prom
       };
     }
 
-    if (health.authReady !== true) {
+    if (health.authReady === false) {
       return {
         ok: false,
         normalizedUrl: normalized.normalizedUrl,
@@ -210,22 +220,24 @@ async function fetchSession(
   timeoutMs: number,
 ): Promise<{ sessionState: SessionState }> {
   const response = await fetchWithTimeout(fetchImpl, url, timeoutMs);
-
-  if (response.status === 401) {
-    return { sessionState: "signed_out" };
-  }
-
-  if (response.status !== 200) {
-    return { sessionState: "unknown" };
-  }
-
   const contentType = response.headers.get("content-type") ?? "";
   if (!contentType.toLowerCase().includes("application/json")) {
     return { sessionState: "unknown" };
   }
 
   const body = await response.json();
-  if (isObject(body) && isObject(body.session) && typeof body.session.userId === "string") {
+
+  if (response.status === 401) {
+    return isPaperclipAuthRequiredPayload(body)
+      ? { sessionState: "signed_out" }
+      : { sessionState: "unknown" };
+  }
+
+  if (response.status !== 200) {
+    return { sessionState: "unknown" };
+  }
+
+  if (isPaperclipSessionPayload(body)) {
     return { sessionState: "signed_in" };
   }
 
@@ -248,15 +260,7 @@ async function fetchWithTimeout(fetchImpl: typeof fetch, url: URL, timeoutMs: nu
   }
 }
 
-function parseHealthPayload(body: unknown): {
-  status: string | null;
-  version: string | null;
-  deploymentMode: DeploymentMode | null;
-  deploymentExposure: DeploymentExposure | null;
-  authReady: boolean | null;
-  bootstrapStatus: BootstrapStatus | null;
-  bootstrapInviteActive: boolean | null;
-} | null {
+function parseHealthPayload(body: unknown): ParsedHealthPayload | null {
   if (!isObject(body)) {
     return null;
   }
@@ -278,8 +282,16 @@ function parseHealthPayload(body: unknown): {
     typeof body.bootstrapInviteActive === "boolean" ? body.bootstrapInviteActive : null;
   const status = typeof body.status === "string" ? body.status : null;
   const version = typeof body.version === "string" ? body.version : null;
+  const hasFullHealthShape = deploymentExposure !== null && authReady !== null;
+  const hasRedactedAuthenticatedShape =
+    status === "ok" &&
+    deploymentMode === "authenticated" &&
+    bootstrapStatus !== null &&
+    bootstrapInviteActive !== null &&
+    deploymentExposure === null &&
+    authReady === null;
 
-  if (!status || !deploymentMode || !deploymentExposure || authReady === null) {
+  if (!status || !deploymentMode || (!hasFullHealthShape && !hasRedactedAuthenticatedShape)) {
     return null;
   }
 
@@ -292,6 +304,23 @@ function parseHealthPayload(body: unknown): {
     bootstrapStatus,
     bootstrapInviteActive,
   };
+}
+
+function isPaperclipAuthRequiredPayload(body: unknown): boolean {
+  return isObject(body) && body.error === "Board authentication required";
+}
+
+function isPaperclipSessionPayload(body: unknown): boolean {
+  if (!isObject(body) || !isObject(body.session)) {
+    return false;
+  }
+
+  return (
+    typeof body.session.id === "string" &&
+    body.session.id.startsWith("paperclip:") &&
+    typeof body.session.userId === "string" &&
+    body.session.userId.length > 0
+  );
 }
 
 function buildFailure(input: {

--- a/test/connection-preflight.test.mjs
+++ b/test/connection-preflight.test.mjs
@@ -55,10 +55,7 @@ test("preflight treats 401 session probe as sign-in required", async () => {
       },
       200,
     ),
-    new Response(JSON.stringify({ error: "Unauthorized" }), {
-      status: 401,
-      headers: { "content-type": "application/json" },
-    }),
+    authRequiredResponse(),
   ];
 
   const result = await preflightRemoteConnection({
@@ -70,6 +67,133 @@ test("preflight treats 401 session probe as sign-in required", async () => {
   assert.equal(result.insecureTransport, false);
   assert.equal(result.sessionState, "signed_out");
   assert.equal(result.bootstrapStatus, "bootstrap_pending");
+});
+
+test("preflight accepts redacted authenticated health with Paperclip auth-required session response", async () => {
+  const responses = [
+    jsonResponse(
+      {
+        status: "ok",
+        deploymentMode: "authenticated",
+        bootstrapStatus: "ready",
+        bootstrapInviteActive: false,
+      },
+      200,
+    ),
+    authRequiredResponse(),
+  ];
+
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net",
+    fetchImpl: async () => responses.shift(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.sessionState, "signed_out");
+  assert.equal(result.deploymentMode, "authenticated");
+  assert.equal(result.deploymentExposure, null);
+  assert.equal(result.authReady, null);
+  assert.equal(result.bootstrapStatus, "ready");
+  assert.equal(result.bootstrapInviteActive, false);
+});
+
+test("preflight accepts redacted authenticated health with active Paperclip session", async () => {
+  const responses = [
+    jsonResponse(
+      {
+        status: "ok",
+        deploymentMode: "authenticated",
+        bootstrapStatus: "bootstrap_pending",
+        bootstrapInviteActive: true,
+      },
+      200,
+    ),
+    jsonResponse(
+      {
+        session: { id: "paperclip:session:user-1", userId: "user-1" },
+        user: { id: "user-1" },
+      },
+      200,
+    ),
+  ];
+
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net/some/path?ignored=true#hash",
+    fetchImpl: async () => responses.shift(),
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.normalizedUrl, "https://paperclip-host.tailnet.ts.net/");
+  assert.equal(result.sessionState, "signed_in");
+  assert.equal(result.bootstrapStatus, "bootstrap_pending");
+  assert.equal(result.bootstrapInviteActive, true);
+});
+
+test("preflight rejects redacted health with generic 401 session response", async () => {
+  const responses = [
+    jsonResponse(
+      {
+        status: "ok",
+        deploymentMode: "authenticated",
+        bootstrapStatus: "ready",
+        bootstrapInviteActive: false,
+      },
+      200,
+    ),
+    jsonResponse({ error: "Unauthorized" }, 401),
+  ];
+
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://example.com",
+    fetchImpl: async () => responses.shift(),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "not_paperclip");
+  assert.equal(result.paperclipDetected, true);
+  assert.equal(result.sessionState, "unknown");
+});
+
+test("preflight rejects redacted health without bootstrap invite state", async () => {
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net",
+    fetchImpl: async () =>
+      jsonResponse(
+        {
+          status: "ok",
+          deploymentMode: "authenticated",
+          bootstrapStatus: "ready",
+        },
+        200,
+      ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "not_paperclip");
+  assert.equal(result.paperclipDetected, false);
+});
+
+test("preflight treats explicit authReady false as auth not ready", async () => {
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net",
+    fetchImpl: async () =>
+      jsonResponse(
+        {
+          status: "ok",
+          version: "2026.403.0",
+          deploymentMode: "authenticated",
+          deploymentExposure: "private",
+          authReady: false,
+          bootstrapStatus: "ready",
+          bootstrapInviteActive: false,
+        },
+        200,
+      ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "auth_not_ready");
+  assert.equal(result.paperclipDetected, true);
 });
 
 test("preflight blocks local_trusted remotes", async () => {
@@ -125,10 +249,7 @@ test("preflight allows http remotes and carries the insecurity warning", async (
       },
       200,
     ),
-    new Response(JSON.stringify({ error: "Unauthorized" }), {
-      status: 401,
-      headers: { "content-type": "application/json" },
-    }),
+    authRequiredResponse(),
   ];
 
   const result = await preflightRemoteConnection({
@@ -154,6 +275,61 @@ test("preflight rejects non-Paperclip endpoints", async () => {
   assert.equal(result.reason, "not_paperclip");
 });
 
+test("preflight rejects health responses that are not HTTP 200", async () => {
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net",
+    fetchImpl: async () =>
+      jsonResponse(
+        {
+          status: "ok",
+          deploymentMode: "authenticated",
+          bootstrapStatus: "ready",
+          bootstrapInviteActive: false,
+        },
+        503,
+      ),
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, "not_paperclip");
+});
+
+test("preflight uses fixed same-origin probe paths and manual redirects", async () => {
+  const calls = [];
+  const responses = [
+    jsonResponse(
+      {
+        status: "ok",
+        deploymentMode: "authenticated",
+        bootstrapStatus: "ready",
+        bootstrapInviteActive: false,
+      },
+      200,
+    ),
+    authRequiredResponse(),
+  ];
+
+  const result = await preflightRemoteConnection({
+    remoteUrl: "https://paperclip-host.tailnet.ts.net/user/input?next=https://evil.test#fragment",
+    fetchImpl: async (input, init) => {
+      calls.push({ url: input.toString(), redirect: init?.redirect });
+      return responses.shift();
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(calls, [
+    {
+      url: "https://paperclip-host.tailnet.ts.net/api/health",
+      redirect: "manual",
+    },
+    {
+      url: "https://paperclip-host.tailnet.ts.net/api/auth/get-session",
+      redirect: "manual",
+    },
+  ]);
+});
+
 test("preflight classifies TLS failures", async () => {
   const result = await preflightRemoteConnection({
     remoteUrl: "https://badcert.example.com",
@@ -172,4 +348,8 @@ function jsonResponse(body, status) {
     status,
     headers: { "content-type": "application/json" },
   });
+}
+
+function authRequiredResponse() {
+  return jsonResponse({ error: "Board authentication required" }, 401);
 }


### PR DESCRIPTION
## Summary

Fixes #10.

This updates Desktop remote preflight so authenticated Paperclip deployments that intentionally redact anonymous `/api/health` can still be verified and opened through the existing sign-in flow.

## Root Cause

Issue #10 was not a Tailnet reachability problem. Users could reach the remote over Tailscale Serve, and `/api/auth/get-session` returned the expected signed-out response for an anonymous request.

The failure was the anonymous `/api/health` contract. Paperclip server redacts detailed health metadata for unauthenticated requests in authenticated mode, returning a compact shape like:

```json
{
  "status": "ok",
  "deploymentMode": "authenticated",
  "bootstrapStatus": "ready",
  "bootstrapInviteActive": false
}
```

Desktop preflight previously required `deploymentExposure` and `authReady` to be present before it considered a host Paperclip. Because the redacted anonymous shape omits those fields, Desktop returned `not_paperclip` before it ever reached the session probe.

## What Changed

- Keep the existing full-health-payload path working.
- Accept a narrow redacted authenticated health shape when:
  - health response status is `200`
  - `status === "ok"`
  - `deploymentMode === "authenticated"`
  - `bootstrapStatus` is valid
  - `bootstrapInviteActive` is boolean
  - `deploymentExposure` and `authReady` are both absent/unknown
- Treat `authReady === false` as `auth_not_ready`, while missing `authReady` means unknown and allows the session probe to continue.
- Tighten `/api/auth/get-session` validation:
  - signed out requires Paperclip's JSON error `{ "error": "Board authentication required" }`
  - signed in requires a Paperclip-shaped session id beginning with `paperclip:` and a non-empty `session.userId`
- Preserve fixed same-origin probe paths and `redirect: "manual"` behavior.

## Why This Shape

The quick two-line workaround from the issue would make redacted health plus any generic `401` enough to call a host verified Paperclip. This PR keeps the compatibility fix, but avoids treating arbitrary `401` responses as proof of Paperclip.

The long-term server-side direction is still to add a stable anonymous discovery marker or endpoint, ideally through a shared schema. This PR is the Desktop-side compatibility and safety fix that works with the current server contract.

## Validation

- `pnpm test:connections` passed: 36/36
- `git diff --check master...HEAD` passed
- `pnpm audit --prod --audit-level low` passed: no known production dependency vulnerabilities

## Audit Note

A full `pnpm audit --audit-level low` still reports pre-existing dev/bundled dependency advisories through `electron-builder`, Electron, and the bundled `@paperclipai/server` dependency tree. Those versions are unchanged from `master` and are not introduced by this PR. They should be handled in a separate dependency-hardening branch.