### PR TITLE
[codex] Add local network exposure mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Under the hood, the app can either:
 
 When local mode is active, the server is cleanly shut down when you quit the app.
 
+Local mode can also be shared on the local network from the launcher. In that mode Desktop still owns the embedded server lifecycle, but starts upstream Paperclip in authenticated LAN mode, binds it to local network interfaces, and shows a LAN URL such as `http://192.168.1.23:3100`. Other devices on the same trusted network can open that URL and sign in through Paperclip's normal auth flow; the host firewall may still need to allow incoming connections.
+
 > For everything Paperclip itself can do — orchestrating AI agents, running autonomous companies, governance, budgets, org charts, etc. — see the **[upstream Paperclip repo](https://github.com/paperclipai/paperclip)**. This project does not modify or extend Paperclip's functionality; it only packages it.
 
 <br/>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "publish-release-assets:mac": "node scripts/publish-macos-release-assets.mjs",
     "smoke:mac:packaged": "node scripts/smoke-test-packaged-macos.mjs",
     "smoke:mac:packaged:lan": "node scripts/smoke-test-packaged-macos.mjs --local-network",
-    "test:connections": "pnpm build && node --test test/connection-validate.test.mjs test/connection-preflight.test.mjs test/connection-profiles.test.mjs test/window-policy.test.mjs test/navigation-gestures.test.mjs test/local-server-lifecycle.test.mjs test/local-server-health.test.mjs test/local-network-exposure.test.mjs",
+    "test:connections": "pnpm build && node --test test/connection-validate.test.mjs test/connection-preflight.test.mjs test/connection-profiles.test.mjs test/window-policy.test.mjs test/navigation-gestures.test.mjs test/local-server-lifecycle.test.mjs test/local-server-health.test.mjs test/local-network-exposure.test.mjs test/local-port-selection.test.mjs",
     "test:prepare-release-assets:mac": "node --test test/prepare-macos-release-assets.test.mjs",
     "test:release-safety": "pnpm build && node --test test/runtime-safety.test.mjs test/prepare-macos-release-assets.test.mjs",
     "release:mac:local": "node scripts/release-macos-local.mjs",
@@ -45,13 +45,22 @@
   "pnpm": {
     "overrides": {
       "@xmldom/xmldom": "0.8.13",
+      "@anthropic-ai/sdk": "0.91.1",
+      "@tootallnate/once": "3.0.1",
+      "better-auth": "1.6.2",
       "brace-expansion@1.1.12": "1.1.13",
       "brace-expansion@2.0.2": "2.0.3",
+      "brace-expansion@5.0.5": "5.0.6",
       "defu": "6.1.7",
       "dompurify": "3.4.2",
       "fast-xml-parser": "5.7.3",
+      "fast-uri": "3.1.2",
+      "kysely": "0.28.17",
       "lodash": "4.18.1",
-      "path-to-regexp": "8.4.2"
+      "path-to-regexp": "8.4.2",
+      "tar": "7.5.14",
+      "undici@5.29.0": "6.24.0",
+      "ws": "8.20.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prepare-release-assets:mac": "node scripts/prepare-macos-release-assets.mjs",
     "publish-release-assets:mac": "node scripts/publish-macos-release-assets.mjs",
     "smoke:mac:packaged": "node scripts/smoke-test-packaged-macos.mjs",
+    "smoke:mac:packaged:lan": "node scripts/smoke-test-packaged-macos.mjs --local-network",
     "test:connections": "pnpm build && node --test test/connection-validate.test.mjs test/connection-preflight.test.mjs test/connection-profiles.test.mjs test/window-policy.test.mjs test/navigation-gestures.test.mjs test/local-server-lifecycle.test.mjs test/local-server-health.test.mjs test/local-network-exposure.test.mjs",
     "test:prepare-release-assets:mac": "node --test test/prepare-macos-release-assets.test.mjs",
     "test:release-safety": "pnpm build && node --test test/runtime-safety.test.mjs test/prepare-macos-release-assets.test.mjs",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "prepare-release-assets:mac": "node scripts/prepare-macos-release-assets.mjs",
     "publish-release-assets:mac": "node scripts/publish-macos-release-assets.mjs",
     "smoke:mac:packaged": "node scripts/smoke-test-packaged-macos.mjs",
-    "test:connections": "pnpm build && node --test test/connection-validate.test.mjs test/connection-preflight.test.mjs test/connection-profiles.test.mjs test/window-policy.test.mjs test/navigation-gestures.test.mjs test/local-server-lifecycle.test.mjs test/local-server-health.test.mjs",
+    "test:connections": "pnpm build && node --test test/connection-validate.test.mjs test/connection-preflight.test.mjs test/connection-profiles.test.mjs test/window-policy.test.mjs test/navigation-gestures.test.mjs test/local-server-lifecycle.test.mjs test/local-server-health.test.mjs test/local-network-exposure.test.mjs",
     "test:prepare-release-assets:mac": "node --test test/prepare-macos-release-assets.test.mjs",
     "test:release-safety": "pnpm build && node --test test/runtime-safety.test.mjs test/prepare-macos-release-assets.test.mjs",
     "release:mac:local": "node scripts/release-macos-local.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,13 +6,22 @@ settings:
 
 overrides:
   '@xmldom/xmldom': 0.8.13
+  '@anthropic-ai/sdk': 0.91.1
+  '@tootallnate/once': 3.0.1
+  better-auth: 1.6.2
   brace-expansion@1.1.12: 1.1.13
   brace-expansion@2.0.2: 2.0.3
+  brace-expansion@5.0.5: 5.0.6
   defu: 6.1.7
   dompurify: 3.4.2
   fast-xml-parser: 5.7.3
+  fast-uri: 3.1.2
+  kysely: 0.28.17
   lodash: 4.18.1
   path-to-regexp: 8.4.2
+  tar: 7.5.14
+  undici@5.29.0: 6.24.0
+  ws: 8.20.1
 
 importers:
 
@@ -30,7 +39,7 @@ importers:
     devDependencies:
       '@paperclipai/server':
         specifier: 2026.513.0
-        version: 2026.513.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+        version: 2026.513.0(@noble/hashes@2.0.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
       electron:
         specifier: ^41.5.0
         version: 41.5.0
@@ -113,8 +122,8 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -295,23 +304,79 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/core@1.4.18':
-    resolution: {integrity: sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==}
+  '@better-auth/core@1.6.2':
+    resolution: {integrity: sha512-nBftDp+eN1fwXor1O4KQorCXa0tJNDgpab7O1z4NcWUU+3faDpdzqLn5mbXZer2E8ZD4VhjqOfYZ041xnBF5NA==}
     peerDependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-call: 1.1.8
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.5
       jose: ^6.1.0
-      kysely: ^0.28.5
+      kysely: 0.28.17
       nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
 
-  '@better-auth/telemetry@1.4.18':
-    resolution: {integrity: sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ==}
+  '@better-auth/drizzle-adapter@1.6.2':
+    resolution: {integrity: sha512-KawrNNuhgmpcc5PgLs6HesMckxCscz5J+BQ99iRmU1cLzG/A87IcydrmYtep+K8WHPN0HmZ/i4z/nOBCtxE2qA==}
     peerDependencies:
-      '@better-auth/core': 1.4.18
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+      drizzle-orm: '>=0.41.0'
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
 
-  '@better-auth/utils@0.3.0':
-    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+  '@better-auth/kysely-adapter@1.6.2':
+    resolution: {integrity: sha512-YMMm75jek/MNCAFWTAaq/U3VPmFnrwZW4NhBjjAwruHQJEIrSZZaOaUEXuUpFRRBhWqg7OOltQcHMwU/45CkuA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+      kysely: 0.28.17
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.2':
+    resolution: {integrity: sha512-QvuK5m7NFgkzLPHyab+NORu3J683nj36Tix58qq6DPcniyY6KZk5gY2yyh4+z1wgSjrxwY5NFx/DC2qz8B8NJg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.2':
+    resolution: {integrity: sha512-IvR2Q+1pjzxA4JXI3ED76+6fsqervIpZ2K5MxoX/+miLQhLEmNcbqqcItg4O2kfkxN8h33/ev57sjTW8QH9Tuw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.2':
+    resolution: {integrity: sha512-bQkXYTo1zPau+xAiMpo1yCjEDSy7i7oeYlkYO+fSfRDCo52DE/9oPOOuI+EStmFkPUNSk9L2rhk8Fulifi8WCg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.2':
+    resolution: {integrity: sha512-o4gHKXqizUxVUUYChZZTowLEzdsz3ViBE/fKFzfHqNFUnF+aVt8QsbLSfipq1WpTIXyJVT/SnH0hgSdWxdssbQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.2
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.4.0':
+    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -668,10 +733,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
@@ -874,6 +935,14 @@ packages:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
   '@paperclipai/adapter-acpx-local@2026.513.0':
     resolution: {integrity: sha512-UBeruw+vV1I3uAOeL5E04ih5Q+JfELKUqX59r75EuIV2nqE9cr1RVJ9a9icTZ3Ka0RwoQcqgHQev0zDUmWwZvg==}
@@ -1159,9 +1228,9 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
+  '@tootallnate/once@3.0.1':
+    resolution: {integrity: sha512-VyMVKRrpHTT8PnotUeV8L/mDaMwD5DaAKCFLP73zAqAtvF0FCqky+Ki7BYbFCYQmqFyTe9316Ed5zS70QUR9eg==}
+    engines: {node: '>= 10'}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -1418,8 +1487,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  better-auth@1.4.18:
-    resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
+  better-auth@1.6.2:
+    resolution: {integrity: sha512-5nqDAIj5xexmnk+GjjdrBknJCabi1mlvsVWJbxs4usHreao4vNdxIxINWDzCyDF9iDR1ildRZdXWSiYPAvTHhA==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1480,8 +1549,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.1.8:
-    resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -1514,8 +1583,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-crc32@0.2.13:
@@ -1825,7 +1894,7 @@ packages:
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
       knex: '*'
-      kysely: '*'
+      kysely: 0.28.17
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
@@ -2056,8 +2125,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -2419,8 +2488,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  kysely@0.28.14:
-    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   lazy-val@1.0.5:
@@ -2544,10 +2613,6 @@ packages:
 
   minipass@3.3.6:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
   minipass@7.1.3:
@@ -2995,8 +3060,8 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3152,11 +3217,6 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
   tar@7.5.14:
     resolution: {integrity: sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw==}
     engines: {node: '>=18'}
@@ -3260,16 +3320,16 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.24.0:
+    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
+    engines: {node: '>=18.17'}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unique-filename@1.1.1:
@@ -3348,8 +3408,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3465,7 +3525,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.121(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -3481,7 +3541,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -3951,24 +4011,57 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)':
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
 
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/drizzle-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+
+  '@better-auth/kysely-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      kysely: 0.28.17
+
+  '@better-auth/memory-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/prisma-adapter@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/telemetry@1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+    dependencies:
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.0': {}
+  '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
 
   '@better-fetch/fetch@1.1.21': {}
 
@@ -3994,7 +4087,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
       '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
-      undici: 5.29.0
+      undici: 6.24.0
 
   '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
     dependencies:
@@ -4266,8 +4359,6 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
-  '@fastify/busboy@2.1.1': {}
-
   '@gar/promisify@1.1.3':
     optional: true
 
@@ -4428,6 +4519,10 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
   '@paperclipai/adapter-acpx-local@2026.513.0':
     dependencies:
       '@agentclientprotocol/claude-agent-acp': 0.31.4
@@ -4475,7 +4570,7 @@ snapshots:
     dependencies:
       '@paperclipai/adapter-utils': 2026.513.0
       picocolors: 1.1.1
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -4492,10 +4587,10 @@ snapshots:
 
   '@paperclipai/adapter-utils@2026.513.0': {}
 
-  '@paperclipai/db@2026.513.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)':
+  '@paperclipai/db@2026.513.0(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(sqlite3@5.1.7)':
     dependencies:
       '@paperclipai/shared': 2026.513.0
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
       postgres: 3.4.8
     transitivePeerDependencies:
@@ -4534,7 +4629,7 @@ snapshots:
       '@paperclipai/shared': 2026.513.0
       zod: 3.25.76
 
-  '@paperclipai/server@2026.513.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)':
+  '@paperclipai/server@2026.513.0(@noble/hashes@2.0.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)':
     dependencies:
       '@aws-sdk/client-s3': 3.1017.0
       '@paperclipai/adapter-acpx-local': 2026.513.0
@@ -4547,17 +4642,17 @@ snapshots:
       '@paperclipai/adapter-opencode-local': 2026.513.0
       '@paperclipai/adapter-pi-local': 2026.513.0
       '@paperclipai/adapter-utils': 2026.513.0
-      '@paperclipai/db': 2026.513.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)
+      '@paperclipai/db': 2026.513.0(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(sqlite3@5.1.7)
       '@paperclipai/plugin-sdk': 2026.513.0
       '@paperclipai/shared': 2026.513.0
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
-      better-auth: 1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0)
+      better-auth: 1.6.2(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0)
       chokidar: 4.0.3
       detect-port: 2.1.0
       dompurify: 3.4.2
       dotenv: 17.3.1
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
       express: 5.2.1
       hermes-paperclip-adapter: 0.2.1
@@ -4568,7 +4663,7 @@ snapshots:
       pino-http: 10.5.0
       pino-pretty: 13.1.3
       sharp: 0.34.5
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 3.25.76
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -4985,7 +5080,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tootallnate/once@1.1.2':
+  '@tootallnate/once@3.0.1':
     optional: true
 
   '@types/cacheable-request@6.0.3':
@@ -5131,7 +5226,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5255,30 +5350,38 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0):
+  better-auth@1.6.2(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))
+      '@better-auth/kysely-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.2(@better-auth/core@1.6.2(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       defu: 6.1.7
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
       pg: 8.20.0
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
-  better-call@1.1.8(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
 
@@ -5324,7 +5427,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5393,7 +5496,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.14
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -5432,7 +5535,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0: {}
+  chownr@2.0.0:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -5645,9 +5749,10 @@ snapshots:
 
   dotenv@17.3.1: {}
 
-  drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7):
     optionalDependencies:
-      kysely: 0.28.14
+      '@opentelemetry/api': 1.9.1
+      kysely: 0.28.17
       pg: 8.20.0
       postgres: 3.4.8
       sqlite3: 5.1.7
@@ -5911,7 +6016,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -6001,6 +6106,7 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -6145,7 +6251,7 @@ snapshots:
 
   http-proxy-agent@4.0.1:
     dependencies:
-      '@tootallnate/once': 1.1.2
+      '@tootallnate/once': 3.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -6286,7 +6392,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.6
+      undici: 7.25.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6328,7 +6434,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kysely@0.28.14: {}
+  kysely@0.28.17: {}
 
   lazy-val@1.0.5: {}
 
@@ -6404,7 +6510,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -6452,8 +6558,7 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@5.0.0: {}
+    optional: true
 
   minipass@7.1.3: {}
 
@@ -6461,6 +6566,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -6472,7 +6578,8 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  mkdirp@1.0.4: {}
+  mkdirp@1.0.4:
+    optional: true
 
   ms@2.1.3: {}
 
@@ -6532,7 +6639,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 6.2.1
+      tar: 7.5.14
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -6924,7 +7031,7 @@ snapshots:
   set-blocking@2.0.0:
     optional: true
 
-  set-cookie-parser@2.7.2: {}
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -7066,7 +7173,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.14
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -7150,15 +7257,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
 
   tar@7.5.14:
     dependencies:
@@ -7271,13 +7369,11 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.24.0: {}
 
   undici@6.25.0: {}
 
-  undici@7.24.6: {}
+  undici@7.25.0: {}
 
   unique-filename@1.1.1:
     dependencies:
@@ -7353,7 +7449,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -34,6 +34,13 @@ if (!serverVersion) {
   process.exit(1);
 }
 
+const runtimeDependencyOverrides = {
+  ...(projectPkg.pnpm?.overrides ?? {}),
+  // cssstyle currently resolves a 5.x css-color release that trips
+  // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
+  "@asamuzakjp/css-color": "4.1.2",
+};
+
 console.log(`[prepare-server] Target server version: @paperclipai/server@${serverVersion}`);
 
 const platform = process.platform;
@@ -169,11 +176,7 @@ for (const arch of targetArches) {
       {
         private: true,
         dependencies: { "@paperclipai/server": serverVersion },
-        overrides: {
-          // cssstyle currently resolves a 5.x css-color release that trips
-          // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
-          "@asamuzakjp/css-color": "4.1.2",
-        },
+        overrides: runtimeDependencyOverrides,
       },
       null,
       2,
@@ -193,6 +196,11 @@ for (const arch of targetArches) {
       },
     },
   );
+
+  execSync("npm audit --omit=dev --audit-level=low", {
+    cwd: stagingDir,
+    stdio: "inherit",
+  });
 
   console.log(`[prepare-server] Assembling server bundle for ${variant}...`);
   mkdirSync(bundleServerDir, { recursive: true });

--- a/scripts/smoke-test-packaged-macos.mjs
+++ b/scripts/smoke-test-packaged-macos.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import http from "node:http";
 import os from "node:os";
 import path from "node:path";
@@ -10,6 +10,7 @@ const args = process.argv.slice(2);
 const appPath = takeOption("--app");
 const timeoutMs = Number.parseInt(takeOption("--timeout-ms") || "90000", 10);
 const keepData = hasFlag("--keep-data");
+const localNetworkMode = hasFlag("--local-network");
 
 if (!appPath) {
   fail("Missing --app /path/to/Paperclip Desktop.app or packaged executable.");
@@ -20,12 +21,16 @@ if (!existsSync(executablePath)) {
   fail(`Packaged executable does not exist: ${executablePath}`);
 }
 
+if (localNetworkMode && findHostPrivateIpv4Addresses().length === 0) {
+  fail("Local network smoke test requires an active RFC1918 IPv4 address.");
+}
+
 const tempRoot = mkdtempSync(path.join(os.tmpdir(), "paperclip-packaged-smoke-"));
 const userDataDir = path.join(tempRoot, "user-data");
 const paperclipHome = path.join(tempRoot, "paperclip-home");
 mkdirSync(userDataDir, { recursive: true });
 mkdirSync(paperclipHome, { recursive: true });
-seedLocalAutoStart(userDataDir);
+seedLocalAutoStart(userDataDir, { localNetworkMode });
 
 const outputChunks = [];
 let child = null;
@@ -34,6 +39,9 @@ let settled = false;
 try {
   const result = await runSmokeTest();
   console.log(`[smoke-macos] Packaged app started local server on ${result.url}`);
+  if (result.localNetworkUrl) {
+    console.log(`[smoke-macos] Packaged app exposed LAN server on ${result.localNetworkUrl}`);
+  }
   console.log(`[smoke-macos] Isolated userData: ${userDataDir}`);
   console.log(`[smoke-macos] Isolated PAPERCLIP_HOME: ${paperclipHome}`);
 } finally {
@@ -69,7 +77,7 @@ function resolveExecutable(inputPath) {
   return path.join(macosDir, entries[0]);
 }
 
-function seedLocalAutoStart(targetUserDataDir) {
+function seedLocalAutoStart(targetUserDataDir, options = {}) {
   const connectionsFile = {
     version: 1,
     state: {
@@ -77,7 +85,8 @@ function seedLocalAutoStart(targetUserDataDir) {
       alwaysShowChooser: false,
       autoConnectLastProfile: true,
       chooserMode: "local_embedded",
-      localProfileName: "Local",
+      localNetworkEnabled: options.localNetworkMode === true,
+      localProfileName: options.localNetworkMode === true ? "Local Network" : "Local",
       localLastHealth: "healthy",
     },
     remoteProfiles: [],
@@ -102,6 +111,13 @@ function runSmokeTest() {
         PAPERCLIP_DESKTOP_REQUIRE_ISOLATED_DATA: "1",
         PAPERCLIP_DESKTOP_USER_DATA_DIR: userDataDir,
         PAPERCLIP_HOME: paperclipHome,
+        ...(localNetworkMode
+          ? {
+              PAPERCLIP_AUTH_PUBLIC_BASE_URL: "https://paperclip.example.com",
+              PAPERCLIP_ALLOWED_HOSTNAMES: "paperclip.example.com",
+              BETTER_AUTH_TRUSTED_ORIGINS: "https://paperclip.example.com",
+            }
+          : {}),
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -136,7 +152,17 @@ function handleOutput(chunk, resolve, reject, timeout) {
     return;
   }
 
-  const match = output.match(/Server listening on\s+(?:127\.0\.0\.1|localhost):(\d+)/);
+  const localNetworkUrl = findLocalNetworkUrl(output);
+  if (localNetworkMode && localNetworkUrl) {
+    const validationError = validateLocalNetworkUrl(localNetworkUrl);
+    if (validationError) {
+      clearTimeout(timeout);
+      reject(new Error(`${validationError}\n${tailOutput()}`));
+      return;
+    }
+  }
+
+  const match = output.match(/Server listening on\s+(?:0\.0\.0\.0|127\.0\.0\.1|localhost):(\d+)/);
   if (!match || settled) {
     return;
   }
@@ -144,15 +170,101 @@ function handleOutput(chunk, resolve, reject, timeout) {
   settled = true;
   const port = Number.parseInt(match[1], 10);
   const url = `http://127.0.0.1:${port}`;
-  void requestOk(`${url}/get-session`)
+  void validateStartedServer({ url, localNetworkUrl })
     .then(() => {
       clearTimeout(timeout);
-      resolve({ url });
+      resolve({ url, localNetworkUrl });
     })
     .catch((error) => {
       clearTimeout(timeout);
       reject(new Error(`Server started but smoke endpoint failed: ${error.message}\n${tailOutput()}`));
     });
+}
+
+async function validateStartedServer({ url, localNetworkUrl }) {
+  if (localNetworkMode && !localNetworkUrl) {
+    throw new Error("Local network mode was requested but no LAN URL was advertised.");
+  }
+
+  await requestOk(`${url}/get-session`);
+
+  if (localNetworkMode) {
+    await requestOk(`${localNetworkUrl}/get-session`);
+    const secret = readLocalNetworkSecret();
+    if (!secret || secret.length < 32) {
+      throw new Error("Local network auth secret was not created or is too weak.");
+    }
+    if (outputIncludes(secret)) {
+      throw new Error("Local network auth secret was written to app output.");
+    }
+  }
+}
+
+function findLocalNetworkUrl(output) {
+  const match = output.match(/Local network access enabled at\s+(http:\/\/[^\s]+)/);
+  return match ? match[1] : null;
+}
+
+function validateLocalNetworkUrl(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return `Local network URL is invalid: ${rawUrl}`;
+  }
+
+  if (parsed.protocol !== "http:") {
+    return `Local network URL must use HTTP for same-LAN access, got: ${rawUrl}`;
+  }
+
+  if (parsed.hostname === "0.0.0.0" || parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
+    return `Local network URL must advertise a concrete LAN address, got: ${rawUrl}`;
+  }
+
+  if (!isPrivateIpv4Address(parsed.hostname)) {
+    return `Local network URL must advertise an RFC1918 IPv4 address, got: ${rawUrl}`;
+  }
+
+  if (!findHostPrivateIpv4Addresses().includes(parsed.hostname)) {
+    return `Local network URL ${rawUrl} is not one of this host's active private IPv4 addresses.`;
+  }
+
+  return null;
+}
+
+function isPrivateIpv4Address(address) {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+
+  const [a, b] = parts;
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+}
+
+function findHostPrivateIpv4Addresses() {
+  const addresses = [];
+  for (const entries of Object.values(os.networkInterfaces())) {
+    if (!entries) continue;
+    for (const entry of entries) {
+      if (!entry.internal && entry.family === "IPv4" && isPrivateIpv4Address(entry.address)) {
+        addresses.push(entry.address);
+      }
+    }
+  }
+  return Array.from(new Set(addresses));
+}
+
+function readLocalNetworkSecret() {
+  try {
+    return readFileSync(path.join(userDataDir, "paperclip-lan-auth-secret"), "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function outputIncludes(value) {
+  return value.length > 0 && outputChunks.join("").includes(value);
 }
 
 function findProductionPathLeak(output) {

--- a/src/connection/local-network-exposure.ts
+++ b/src/connection/local-network-exposure.ts
@@ -55,40 +55,26 @@ export function readOrCreateLocalNetworkAuthSecret(userDataPath: string): string
 export function buildLocalNetworkExposureConfig(input: {
   port: number;
   authSecret: string;
-  baseEnv?: NodeJS.ProcessEnv;
   hostname?: string;
   interfaces?: NetworkInterfaceMap;
 }): LocalNetworkExposureConfig {
-  const baseEnv = input.baseEnv ?? process.env;
   const addresses = listLocalNetworkIpv4Addresses(input.interfaces);
   if (addresses.length === 0) {
     throw new Error("No active IPv4 local network address was found.");
   }
 
   const hostname = normalizeHostname(input.hostname ?? os.hostname());
-  const existingAllowedHostnames = parseCsv(baseEnv.PAPERCLIP_ALLOWED_HOSTNAMES);
   const allowedHostnames = uniqueStrings([
-    ...existingAllowedHostnames,
     ...addresses,
     ...(hostname && !isLoopbackHostname(hostname) ? [hostname] : []),
     "localhost",
     "127.0.0.1",
   ]);
 
-  const fallbackPublicBaseUrl = `http://${addresses[0]}:${input.port}`;
-  const authPublicBaseUrl = firstNonEmpty([
-    baseEnv.PAPERCLIP_AUTH_PUBLIC_BASE_URL,
-    baseEnv.BETTER_AUTH_URL,
-    baseEnv.BETTER_AUTH_BASE_URL,
-    baseEnv.PAPERCLIP_PUBLIC_URL,
-  ]) ?? fallbackPublicBaseUrl;
-  const authSecret = firstNonEmpty([
-    baseEnv.BETTER_AUTH_SECRET,
-    baseEnv.PAPERCLIP_AGENT_JWT_SECRET,
-    input.authSecret,
-  ]);
+  const authPublicBaseUrl = `http://${addresses[0]}:${input.port}`;
+  const authSecret = input.authSecret.trim();
 
-  if (!authSecret) {
+  if (!isStrongAuthSecret(authSecret)) {
     throw new Error("Local network mode requires an auth secret.");
   }
 
@@ -102,6 +88,7 @@ export function buildLocalNetworkExposureConfig(input: {
       PAPERCLIP_BIND: "lan",
       PAPERCLIP_ALLOWED_HOSTNAMES: allowedHostnames.join(","),
       PAPERCLIP_AUTH_PUBLIC_BASE_URL: authPublicBaseUrl,
+      PAPERCLIP_PUBLIC_URL: authPublicBaseUrl,
       BETTER_AUTH_SECRET: authSecret,
     },
   };
@@ -133,13 +120,6 @@ function secureSecretFile(secretPath: string): void {
   }
 }
 
-function parseCsv(value: string | undefined): string[] {
-  return (value ?? "")
-    .split(",")
-    .map(normalizeHostname)
-    .filter(Boolean);
-}
-
 function normalizeHostname(value: string | undefined): string {
   return (value ?? "").trim().toLowerCase();
 }
@@ -150,8 +130,4 @@ function isLoopbackHostname(value: string): boolean {
 
 function uniqueStrings(values: string[]): string[] {
   return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
-}
-
-function firstNonEmpty(values: Array<string | undefined>): string | undefined {
-  return values.map((value) => value?.trim()).find((value): value is string => !!value);
 }

--- a/src/connection/local-network-exposure.ts
+++ b/src/connection/local-network-exposure.ts
@@ -66,7 +66,7 @@ export function buildLocalNetworkExposureConfig(input: {
   const hostname = normalizeHostname(input.hostname ?? os.hostname());
   const allowedHostnames = uniqueStrings([
     ...addresses,
-    ...(hostname && !isLoopbackHostname(hostname) ? [hostname] : []),
+    ...(isSafeLocalHostname(hostname) ? [hostname] : []),
     "localhost",
     "127.0.0.1",
   ]);
@@ -126,6 +126,20 @@ function normalizeHostname(value: string | undefined): string {
 
 function isLoopbackHostname(value: string): boolean {
   return value === "localhost" || value === "127.0.0.1" || value === "::1";
+}
+
+function isSafeLocalHostname(value: string): boolean {
+  if (!value || isLoopbackHostname(value)) {
+    return false;
+  }
+
+  return (
+    !value.includes(".") ||
+    value.endsWith(".local") ||
+    value.endsWith(".lan") ||
+    value.endsWith(".home") ||
+    value.endsWith(".internal")
+  );
 }
 
 function uniqueStrings(values: string[]): string[] {

--- a/src/connection/local-network-exposure.ts
+++ b/src/connection/local-network-exposure.ts
@@ -1,0 +1,148 @@
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const LOCAL_NETWORK_AUTH_SECRET_FILE_NAME = "paperclip-lan-auth-secret";
+
+export interface LocalNetworkExposureConfig {
+  env: Record<string, string>;
+  primaryUrl: string;
+  allowedHostnames: string[];
+  addresses: string[];
+}
+
+type NetworkInterfaceMap = ReturnType<typeof os.networkInterfaces>;
+
+export function listLocalNetworkIpv4Addresses(
+  interfaces: NetworkInterfaceMap = os.networkInterfaces(),
+): string[] {
+  const addresses: string[] = [];
+
+  for (const entries of Object.values(interfaces)) {
+    if (!entries) continue;
+
+    for (const entry of entries) {
+      if (entry.internal || entry.family !== "IPv4" || !isUsableIpv4Address(entry.address)) {
+        continue;
+      }
+      addresses.push(entry.address);
+    }
+  }
+
+  return Array.from(new Set(addresses));
+}
+
+export function readOrCreateLocalNetworkAuthSecret(userDataPath: string): string {
+  const secretPath = path.join(userDataPath, LOCAL_NETWORK_AUTH_SECRET_FILE_NAME);
+  try {
+    const existing = fs.readFileSync(secretPath, "utf8").trim();
+    if (existing) {
+      return existing;
+    }
+  } catch {
+    // create below
+  }
+
+  const secret = randomBytes(32).toString("base64url");
+  fs.mkdirSync(path.dirname(secretPath), { recursive: true });
+  fs.writeFileSync(secretPath, `${secret}\n`, { encoding: "utf8", mode: 0o600 });
+  try {
+    fs.chmodSync(secretPath, 0o600);
+  } catch {
+    // best effort on platforms that do not support chmod
+  }
+  return secret;
+}
+
+export function buildLocalNetworkExposureConfig(input: {
+  port: number;
+  authSecret: string;
+  baseEnv?: NodeJS.ProcessEnv;
+  hostname?: string;
+  interfaces?: NetworkInterfaceMap;
+}): LocalNetworkExposureConfig {
+  const baseEnv = input.baseEnv ?? process.env;
+  const addresses = listLocalNetworkIpv4Addresses(input.interfaces);
+  if (addresses.length === 0) {
+    throw new Error("No active IPv4 local network address was found.");
+  }
+
+  const hostname = normalizeHostname(input.hostname ?? os.hostname());
+  const existingAllowedHostnames = parseCsv(baseEnv.PAPERCLIP_ALLOWED_HOSTNAMES);
+  const allowedHostnames = uniqueStrings([
+    ...existingAllowedHostnames,
+    ...addresses,
+    ...(hostname && !isLoopbackHostname(hostname) ? [hostname] : []),
+    "localhost",
+    "127.0.0.1",
+  ]);
+
+  const fallbackPublicBaseUrl = `http://${addresses[0]}:${input.port}`;
+  const authPublicBaseUrl = firstNonEmpty([
+    baseEnv.PAPERCLIP_AUTH_PUBLIC_BASE_URL,
+    baseEnv.BETTER_AUTH_URL,
+    baseEnv.BETTER_AUTH_BASE_URL,
+    baseEnv.PAPERCLIP_PUBLIC_URL,
+  ]) ?? fallbackPublicBaseUrl;
+  const authSecret = firstNonEmpty([
+    baseEnv.BETTER_AUTH_SECRET,
+    baseEnv.PAPERCLIP_AGENT_JWT_SECRET,
+    input.authSecret,
+  ]);
+
+  if (!authSecret) {
+    throw new Error("Local network mode requires an auth secret.");
+  }
+
+  return {
+    primaryUrl: authPublicBaseUrl,
+    addresses,
+    allowedHostnames,
+    env: {
+      PAPERCLIP_DEPLOYMENT_MODE: "authenticated",
+      PAPERCLIP_DEPLOYMENT_EXPOSURE: "private",
+      PAPERCLIP_BIND: "lan",
+      PAPERCLIP_ALLOWED_HOSTNAMES: allowedHostnames.join(","),
+      PAPERCLIP_AUTH_PUBLIC_BASE_URL: authPublicBaseUrl,
+      BETTER_AUTH_SECRET: authSecret,
+    },
+  };
+}
+
+function isUsableIpv4Address(address: string): boolean {
+  const parts = address.split(".").map((part) => Number(part));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+
+  const [a, b] = parts;
+  return (
+    a !== 0 &&
+    a !== 127 &&
+    !(a === 169 && b === 254)
+  );
+}
+
+function parseCsv(value: string | undefined): string[] {
+  return (value ?? "")
+    .split(",")
+    .map(normalizeHostname)
+    .filter(Boolean);
+}
+
+function normalizeHostname(value: string | undefined): string {
+  return (value ?? "").trim().toLowerCase();
+}
+
+function isLoopbackHostname(value: string): boolean {
+  return value === "localhost" || value === "127.0.0.1" || value === "::1";
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.map((value) => value.trim()).filter(Boolean)));
+}
+
+function firstNonEmpty(values: Array<string | undefined>): string | undefined {
+  return values.map((value) => value?.trim()).find((value): value is string => !!value);
+}

--- a/src/connection/local-network-exposure.ts
+++ b/src/connection/local-network-exposure.ts
@@ -37,7 +37,8 @@ export function readOrCreateLocalNetworkAuthSecret(userDataPath: string): string
   const secretPath = path.join(userDataPath, LOCAL_NETWORK_AUTH_SECRET_FILE_NAME);
   try {
     const existing = fs.readFileSync(secretPath, "utf8").trim();
-    if (existing) {
+    if (isStrongAuthSecret(existing)) {
+      secureSecretFile(secretPath);
       return existing;
     }
   } catch {
@@ -47,11 +48,7 @@ export function readOrCreateLocalNetworkAuthSecret(userDataPath: string): string
   const secret = randomBytes(32).toString("base64url");
   fs.mkdirSync(path.dirname(secretPath), { recursive: true });
   fs.writeFileSync(secretPath, `${secret}\n`, { encoding: "utf8", mode: 0o600 });
-  try {
-    fs.chmodSync(secretPath, 0o600);
-  } catch {
-    // best effort on platforms that do not support chmod
-  }
+  secureSecretFile(secretPath);
   return secret;
 }
 
@@ -118,10 +115,22 @@ function isUsableIpv4Address(address: string): boolean {
 
   const [a, b] = parts;
   return (
-    a !== 0 &&
-    a !== 127 &&
-    !(a === 169 && b === 254)
+    a === 10 ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 168)
   );
+}
+
+function isStrongAuthSecret(value: string): boolean {
+  return value.length >= 32;
+}
+
+function secureSecretFile(secretPath: string): void {
+  try {
+    fs.chmodSync(secretPath, 0o600);
+  } catch {
+    // best effort on platforms that do not support chmod
+  }
 }
 
 function parseCsv(value: string | undefined): string[] {

--- a/src/connection/local-network-exposure.ts
+++ b/src/connection/local-network-exposure.ts
@@ -87,9 +87,13 @@ export function buildLocalNetworkExposureConfig(input: {
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private",
       PAPERCLIP_BIND: "lan",
       PAPERCLIP_ALLOWED_HOSTNAMES: allowedHostnames.join(","),
+      PAPERCLIP_AUTH_BASE_URL_MODE: "explicit",
       PAPERCLIP_AUTH_PUBLIC_BASE_URL: authPublicBaseUrl,
       PAPERCLIP_PUBLIC_URL: authPublicBaseUrl,
+      BETTER_AUTH_URL: authPublicBaseUrl,
+      BETTER_AUTH_BASE_URL: authPublicBaseUrl,
       BETTER_AUTH_SECRET: authSecret,
+      BETTER_AUTH_TRUSTED_ORIGINS: "",
     },
   };
 }

--- a/src/connection/local-port-selection.ts
+++ b/src/connection/local-port-selection.ts
@@ -1,0 +1,41 @@
+import net from "node:net";
+
+export type LocalServerBindHost = "127.0.0.1" | "0.0.0.0";
+
+export function bindHostForLocalExposure(exposeOnLocalNetwork: boolean): LocalServerBindHost {
+  return exposeOnLocalNetwork ? "0.0.0.0" : "127.0.0.1";
+}
+
+export function isPortAvailableForHost(port: number, host: LocalServerBindHost): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    let settled = false;
+
+    const settle = (available: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(available);
+    };
+
+    server.once("error", () => {
+      settle(false);
+    });
+    server.listen({ port, host, exclusive: true }, () => {
+      server.close(() => settle(true));
+    });
+  });
+}
+
+export async function findFreePortForHost(
+  startPort: number,
+  host: LocalServerBindHost,
+  maxAttempts = 100,
+): Promise<number> {
+  for (let port = startPort; port < startPort + maxAttempts; port += 1) {
+    if (await isPortAvailableForHost(port, host)) {
+      return port;
+    }
+  }
+
+  throw new Error(`No free port found on ${host} in range ${startPort}-${startPort + maxAttempts - 1}`);
+}

--- a/src/connection/local-server-lifecycle.ts
+++ b/src/connection/local-server-lifecycle.ts
@@ -47,3 +47,12 @@ export function shouldStopAttemptedServer(
 ): boolean {
   return isSameProcess(tracked, attempted);
 }
+
+export function shouldStopPreviousLocalServerForExposureChange(input: {
+  previousMode: string | null | undefined;
+  currentExposeOnLocalNetwork: boolean | null | undefined;
+  nextExposeOnLocalNetwork: boolean;
+}): boolean {
+  return input.previousMode === "local_embedded"
+    && (input.currentExposeOnLocalNetwork === true) !== input.nextExposeOnLocalNetwork;
+}

--- a/src/connection/profiles.ts
+++ b/src/connection/profiles.ts
@@ -27,6 +27,7 @@ export function createDefaultConnectionState(): ConnectionState {
     autoConnectLastProfile: false,
     chooserMode: "local_embedded",
     localProfileName: "Local",
+    localNetworkEnabled: false,
     localLastHealth: "healthy",
   };
 }
@@ -171,6 +172,11 @@ export class ConnectionStore {
     this.persist();
   }
 
+  setLocalNetworkEnabled(value: boolean): void {
+    this.cache.state.localNetworkEnabled = value;
+    this.persist();
+  }
+
   setRememberedProfile(profileId: string | null, rememberChoice: boolean): void {
     this.cache.state.activeProfileId = profileId;
     this.cache.state.autoConnectLastProfile = rememberChoice;
@@ -295,6 +301,7 @@ function sanitizeConnectionState(raw: unknown): ConnectionState {
       typeof raw.localProfileName === "string" && raw.localProfileName.trim().length > 0
         ? raw.localProfileName.trim()
         : "Local",
+    localNetworkEnabled: raw.localNetworkEnabled === true,
     localLastConnectedAt:
       typeof raw.localLastConnectedAt === "string" ? raw.localLastConnectedAt : undefined,
     localLastHealth: sanitizeHealth(raw.localLastHealth) ?? "healthy",

--- a/src/connection/types.ts
+++ b/src/connection/types.ts
@@ -42,6 +42,7 @@ export interface ConnectionState {
   autoConnectLastProfile: boolean;
   chooserMode: ConnectionMode;
   localProfileName: string;
+  localNetworkEnabled: boolean;
   localLastConnectedAt?: string;
   localLastHealth?: ConnectionHealth;
 }

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -133,6 +133,28 @@ export function getLauncherHtml(): string {
     max-width: 300px;
   }
 
+  .local-network-panel {
+    width: 340px;
+    margin-top: 18px;
+    padding: 12px;
+    border: 1px solid #27272a;
+    border-radius: 8px;
+    background: #111114;
+  }
+  .local-network-panel .remember-row {
+    margin: 0;
+    align-items: flex-start;
+  }
+  .local-network-title {
+    color: #e4e4e7;
+  }
+  .local-network-detail {
+    display: block;
+    margin-top: 4px;
+    color: #71717a;
+    line-height: 1.35;
+  }
+
   .remember-row {
     display: flex;
     align-items: center;
@@ -860,6 +882,12 @@ export function getLauncherHtml(): string {
       <div class="local-hero-title">Run Local Server</div>
       <div class="local-hero-desc">Start the embedded Paperclip server on this machine with trusted local access.</div>
       <button class="btn primary" style="min-width:180px;" onclick="launchLocal()">Launch</button>
+      <div class="local-network-panel">
+        <div class="remember-row">
+          <input type="checkbox" id="shareLocalNetwork">
+          <label for="shareLocalNetwork"><span class="local-network-title">Share on local network</span><span class="local-network-detail">Requires sign-in and allows devices on this network to reach Paperclip over HTTP.</span></label>
+        </div>
+      </div>
       <div class="remember-row" style="margin-top:20px;margin-bottom:0;">
         <input type="checkbox" id="rememberLocal">
         <label for="rememberLocal">Always start local on launch</label>
@@ -1093,6 +1121,10 @@ function getRemoteInsecureHttpChoice() {
   return !!document.getElementById("allowInsecureHttp")?.checked;
 }
 
+function getLocalNetworkChoice() {
+  return !!document.getElementById("shareLocalNetwork")?.checked;
+}
+
 function setRemoteInsecureHttpChoice(checked) {
   const checkbox = document.getElementById("allowInsecureHttp");
   if (checkbox) checkbox.checked = !!checked;
@@ -1269,11 +1301,12 @@ function renderTabRemoteList() {
 
 async function launchLocal() {
   const rememberChoice = document.getElementById("rememberLocal").checked;
+  const exposeOnLocalNetwork = getLocalNetworkChoice();
   await launcher.setChooserMode("local_embedded");
-  lastErrorAction = { type: "local", rememberChoice };
+  lastErrorAction = { type: "local", rememberChoice, exposeOnLocalNetwork };
   resetLocalBoot();
   showView("local-boot");
-  await launcher.connectLocal({ rememberChoice });
+  await launcher.connectLocal({ rememberChoice, exposeOnLocalNetwork });
 }
 
 function openAddRemoteFromChooser() {
@@ -1446,7 +1479,10 @@ async function retryLastAction() {
   if (lastErrorAction.type === "local") {
     resetLocalBoot();
     showView("local-boot");
-    await launcher.connectLocal({ rememberChoice: !!lastErrorAction.rememberChoice });
+    await launcher.connectLocal({
+      rememberChoice: !!lastErrorAction.rememberChoice,
+      exposeOnLocalNetwork: !!lastErrorAction.exposeOnLocalNetwork,
+    });
     return;
   }
 
@@ -1499,10 +1535,13 @@ function configureErrorButtons() {
 
 async function switchToLocal() {
   const rememberChoice = false;
-  lastErrorAction = { type: "local", rememberChoice };
+  const exposeOnLocalNetwork = false;
+  const localNetworkCheckbox = document.getElementById("shareLocalNetwork");
+  if (localNetworkCheckbox) localNetworkCheckbox.checked = false;
+  lastErrorAction = { type: "local", rememberChoice, exposeOnLocalNetwork };
   resetLocalBoot();
   showView("local-boot");
-  await launcher.connectLocal({ rememberChoice });
+  await launcher.connectLocal({ rememberChoice, exposeOnLocalNetwork });
 }
 
 async function closeLauncherSheet() {
@@ -1943,6 +1982,7 @@ function applySnapshot(nextSnapshot) {
   document.getElementById("rememberLocal").checked =
     !nextSnapshot.state.alwaysShowChooser && nextSnapshot.state.autoConnectLastProfile
     && nextSnapshot.state.chooserMode !== "remote_existing";
+  document.getElementById("shareLocalNetwork").checked = !!nextSnapshot.state.localNetworkEnabled;
   renderConnections();
   renderTabRemoteList();
   updateWindowClose(activeView || nextSnapshot.initialView || "chooser");

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -133,26 +133,69 @@ export function getLauncherHtml(): string {
     max-width: 300px;
   }
 
-  .local-network-panel {
-    width: 340px;
+  .local-options {
     margin-top: 18px;
-    padding: 12px;
-    border: 1px solid #27272a;
-    border-radius: 8px;
-    background: #111114;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
-  .local-network-panel .remember-row {
+  .local-options .remember-row {
+    margin-bottom: 10px;
+    justify-content: center;
+  }
+  .local-options .remember-row:last-child {
     margin: 0;
-    align-items: flex-start;
   }
-  .local-network-title {
+  .local-network-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .local-network-info {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: #27272a;
+    color: #a1a1aa;
+    font-size: 10px;
+    font-weight: 600;
+    cursor: help;
+    user-select: none;
+    flex-shrink: 0;
+  }
+  .local-network-info:hover,
+  .local-network-info:focus {
+    background: #3f3f46;
     color: #e4e4e7;
   }
-  .local-network-detail {
-    display: block;
-    margin-top: 4px;
-    color: #71717a;
-    line-height: 1.35;
+  .local-network-tooltip {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: 260px;
+    padding: 8px 10px;
+    background: #0a0a0b;
+    border: 1px solid #3f3f46;
+    border-radius: 6px;
+    color: #d4d4d8;
+    font-size: 11px;
+    font-weight: 400;
+    line-height: 1.4;
+    text-align: left;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.12s ease;
+    z-index: 10;
+    white-space: normal;
+  }
+  .local-network-info:hover .local-network-tooltip,
+  .local-network-info:focus .local-network-tooltip {
+    opacity: 1;
   }
 
   .remember-row {
@@ -882,15 +925,15 @@ export function getLauncherHtml(): string {
       <div class="local-hero-title">Run Local Server</div>
       <div class="local-hero-desc">Start the embedded Paperclip server on this machine with trusted local access.</div>
       <button class="btn primary" style="min-width:180px;" onclick="launchLocal()">Launch</button>
-      <div class="local-network-panel">
+      <div class="local-options">
         <div class="remember-row">
           <input type="checkbox" id="shareLocalNetwork">
-          <label for="shareLocalNetwork"><span class="local-network-title">Share on local network</span><span class="local-network-detail">Requires sign-in and allows devices on this network to reach Paperclip over HTTP.</span></label>
+          <label class="local-network-label" for="shareLocalNetwork">Share on local network <span class="local-network-info" tabindex="0" aria-label="Local network sharing details">?<span class="local-network-tooltip">Lets other devices on the same trusted network open this local Paperclip server over HTTP. Paperclip still runs in authenticated mode and your Mac may ask to allow incoming connections.</span></span></label>
         </div>
-      </div>
-      <div class="remember-row" style="margin-top:20px;margin-bottom:0;">
-        <input type="checkbox" id="rememberLocal">
-        <label for="rememberLocal">Always start local on launch</label>
+        <div class="remember-row">
+          <input type="checkbox" id="rememberLocal">
+          <label for="rememberLocal">Always start local on launch</label>
+        </div>
       </div>
     </div>
 

--- a/src/launcher-preload.ts
+++ b/src/launcher-preload.ts
@@ -9,7 +9,8 @@ contextBridge.exposeInMainWorld("paperclipLauncher", {
   duplicateProfile: (profileId: string) => ipcRenderer.invoke("launcher:duplicate-profile", profileId),
   deleteProfile: (profileId: string) => ipcRenderer.invoke("launcher:delete-profile", profileId),
   verifyRemote: (payload: { remoteUrl: string }) => ipcRenderer.invoke("launcher:verify-remote", payload),
-  connectLocal: (payload: { rememberChoice: boolean }) => ipcRenderer.invoke("launcher:connect-local", payload),
+  connectLocal: (payload: { rememberChoice: boolean; exposeOnLocalNetwork?: boolean }) =>
+    ipcRenderer.invoke("launcher:connect-local", payload),
   connectRemote: (payload: {
     profileId?: string;
     remoteUrl: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,9 +20,11 @@ import { checkForUpdatesFromMenu, initAutoUpdater } from "./updater";
 import { getLauncherHtml } from "./launcher-html";
 import { handleSwipeNavigation } from "./navigation-gestures";
 import {
+  isSameProcess,
   shouldHandleTrackedServerExit,
   shouldKillSupersededServer,
   shouldRestorePreviousTrackedServer,
+  shouldStopPreviousLocalServerForExposureChange,
   shouldStopAttemptedServer,
 } from "./connection/local-server-lifecycle";
 import { probeLocalServerHealth } from "./connection/local-server-health";
@@ -947,7 +949,12 @@ async function bootLocal(options: {
   }
 
   const previousConnectionMode = currentConnection?.mode ?? null;
-  const previousServerProcess = previousConnectionMode === "local_embedded" ? serverProcess : null;
+  let previousServerProcess = previousConnectionMode === "local_embedded" ? serverProcess : null;
+  const switchingLocalExposure = shouldStopPreviousLocalServerForExposureChange({
+    previousMode: previousConnectionMode,
+    currentExposeOnLocalNetwork: currentConnection?.localNetworkEnabled,
+    nextExposeOnLocalNetwork: exposeOnLocalNetwork,
+  });
   let nextServerProcess: ChildProcess | null = null;
   await ensureLauncherWindow("local-boot");
 
@@ -960,6 +967,15 @@ async function bootLocal(options: {
     }
 
     sendBootStatus("database", "Launching embedded PostgreSQL...", 15);
+    if (switchingLocalExposure) {
+      sendBootStatus("server", "Restarting local server...", 25);
+      await killChildProcess(previousServerProcess);
+      if (isSameProcess(serverProcess, previousServerProcess)) {
+        trackServerProcess(null);
+      }
+      previousServerProcess = null;
+    }
+
     const launch = startServer(serverPort, { exposeOnLocalNetwork });
     nextServerProcess = launch.process;
     trackServerProcess(nextServerProcess);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   ipcMain,
   Menu,
@@ -1516,6 +1517,12 @@ function rebuildAppMenu(): void {
 function buildConnectionMenuItems(): MenuItemConstructorOptions[] {
   const snapshot = connectionStore.getSnapshot();
   const recentProfiles = connectionStore.getRecentRemoteProfiles(5);
+  const activeLocalNetworkUrl =
+    currentConnection?.mode === "local_embedded"
+    && currentConnection.localNetworkEnabled === true
+    && currentConnection.localNetworkUrl
+      ? currentConnection.localNetworkUrl
+      : null;
 
   const items: MenuItemConstructorOptions[] = [
     {
@@ -1552,6 +1559,28 @@ function buildConnectionMenuItems(): MenuItemConstructorOptions[] {
       },
     },
   ];
+
+  if (activeLocalNetworkUrl) {
+    items.push({ type: "separator" });
+    items.push(
+      {
+        label: `Local Network URL: ${activeLocalNetworkUrl}`,
+        enabled: false,
+      },
+      {
+        label: "Copy Local Network URL",
+        click: () => {
+          clipboard.writeText(activeLocalNetworkUrl);
+        },
+      },
+      {
+        label: "Open Local Network URL",
+        click: () => {
+          void shell.openExternal(activeLocalNetworkUrl);
+        },
+      },
+    );
+  }
 
   if (recentProfiles.length > 0) {
     items.push({ type: "separator" });

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,10 @@ import {
   buildLocalNetworkExposureConfig,
   readOrCreateLocalNetworkAuthSecret,
 } from "./connection/local-network-exposure";
+import {
+  bindHostForLocalExposure,
+  findFreePortForHost,
+} from "./connection/local-port-selection";
 import { preflightRemoteConnection } from "./connection/preflight";
 import { ConnectionStore, getConnectionsFilePath } from "./connection/profiles";
 import { normalizeRemoteUrl } from "./connection/validate";
@@ -155,26 +159,6 @@ function ensureLauncherHtmlFile(): string {
 // ---------------------------------------------------------------------------
 // Port detection and server lifecycle
 // ---------------------------------------------------------------------------
-
-function isPortInUse(port: number): Promise<boolean> {
-  return new Promise((resolve) => {
-    const sock = net.createConnection({ port, host: "127.0.0.1" }, () => {
-      sock.destroy();
-      resolve(true);
-    });
-    sock.on("error", () => resolve(false));
-  });
-}
-
-async function findFreePort(startPort: number): Promise<number> {
-  for (let port = startPort; port < startPort + 100; port += 1) {
-    if (!(await isPortInUse(port))) {
-      return port;
-    }
-  }
-
-  throw new Error(`No free port found in range ${startPort}-${startPort + 99}`);
-}
 
 function waitForPort(port: number, timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -962,7 +946,7 @@ async function bootLocal(options: {
   try {
     sendBootStatus("init", "Preparing environment...", 5);
 
-    serverPort = await findFreePort(PREFERRED_PORT);
+    serverPort = await findFreePortForHost(PREFERRED_PORT, bindHostForLocalExposure(exposeOnLocalNetwork));
     if (bootId !== bootSequence) {
       return;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,10 @@ import {
   shouldStopAttemptedServer,
 } from "./connection/local-server-lifecycle";
 import { probeLocalServerHealth } from "./connection/local-server-health";
+import {
+  buildLocalNetworkExposureConfig,
+  readOrCreateLocalNetworkAuthSecret,
+} from "./connection/local-network-exposure";
 import { preflightRemoteConnection } from "./connection/preflight";
 import { ConnectionStore, getConnectionsFilePath } from "./connection/profiles";
 import { normalizeRemoteUrl } from "./connection/validate";
@@ -79,6 +83,8 @@ let currentConnection: {
   startUrl: string;
   allowedOrigin: string;
   partition: string;
+  localNetworkEnabled?: boolean;
+  localNetworkUrl?: string;
 } | null = null;
 
 let connectionStore: ConnectionStore;
@@ -92,6 +98,10 @@ type LauncherView =
   | "error";
 type LauncherPresentation = "standalone" | "attached";
 type BootStep = "init" | "database" | "server" | "ready";
+interface LocalServerLaunch {
+  process: ChildProcess;
+  localNetworkUrl?: string;
+}
 
 app.setName("Paperclip");
 applyDesktopUserDataOverride(app, process.env);
@@ -322,23 +332,37 @@ function resolvePaperclipHome(): string {
   });
 }
 
-function startServer(port: number): ChildProcess {
+function startServer(port: number, options: { exposeOnLocalNetwork?: boolean } = {}): LocalServerLaunch {
   const root = getAppRoot();
   const isWindows = process.platform === "win32";
   const enrichedPath = resolveShellPath();
   const paperclipHome = resolvePaperclipHome();
   console.log(`Using PAPERCLIP_HOME: ${paperclipHome}`);
+  const localNetworkExposure = options.exposeOnLocalNetwork
+    ? buildLocalNetworkExposureConfig({
+        port,
+        authSecret: readOrCreateLocalNetworkAuthSecret(app.getPath("userData")),
+        baseEnv: process.env,
+      })
+    : null;
+  if (localNetworkExposure) {
+    console.log(`Local network access enabled at ${localNetworkExposure.primaryUrl}`);
+  }
+  const commonEnv = {
+    ...process.env,
+    PATH: enrichedPath,
+    PORT: String(port),
+    PAPERCLIP_HOME: paperclipHome,
+    PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
+    ...(localNetworkExposure?.env ?? {}),
+  };
 
   const child = app.isPackaged
     ? spawn(findNodeBinary(), [path.join(root, "server", "dist", "index.js")], {
         cwd: root,
         env: {
-          ...process.env,
-          PATH: enrichedPath,
+          ...commonEnv,
           NODE_ENV: "production",
-          PORT: String(port),
-          PAPERCLIP_HOME: paperclipHome,
-          PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: !isWindows,
@@ -346,12 +370,8 @@ function startServer(port: number): ChildProcess {
     : spawn("node", [path.join(root, "node_modules", "@paperclipai", "server", "dist", "index.js")], {
         cwd: root,
         env: {
-          ...process.env,
-          PATH: enrichedPath,
+          ...commonEnv,
           NODE_ENV: "development",
-          PORT: String(port),
-          PAPERCLIP_HOME: paperclipHome,
-          PAPERCLIP_MIGRATION_AUTO_APPLY: "true",
         },
         stdio: ["ignore", "pipe", "pipe"],
         detached: !isWindows,
@@ -363,7 +383,10 @@ function startServer(port: number): ChildProcess {
 
   child.stdout?.on("data", (chunk: Buffer) => process.stdout.write(chunk));
   child.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk));
-  return child;
+  return {
+    process: child,
+    localNetworkUrl: localNetworkExposure?.primaryUrl,
+  };
 }
 
 function killServer(): Promise<void> {
@@ -481,8 +504,9 @@ async function promptToRecoverLocalServer(input: {
       : await dialog.showMessageBox(messageBoxOptions);
 
     if (response === 0) {
+      const exposeOnLocalNetwork = currentConnection?.localNetworkEnabled === true;
       await ensureLauncherWindow("local-boot");
-      void bootLocal({ forceRestart: true });
+      void bootLocal({ forceRestart: true, exposeOnLocalNetwork });
       return;
     }
 
@@ -719,7 +743,7 @@ function describeCurrentConnection(): string | null {
   }
 
   if (currentConnection.mode === "local_embedded") {
-    return "Return to Local";
+    return currentConnection.localNetworkEnabled ? "Return to Local Network" : "Return to Local";
   }
 
   const profile = currentConnection.profileId
@@ -896,12 +920,21 @@ async function bootLocal(options: {
   rememberChoiceExplicit?: boolean;
   rememberChoice?: boolean;
   forceRestart?: boolean;
+  exposeOnLocalNetwork?: boolean;
 } = {}): Promise<void> {
   const bootId = ++bootSequence;
+  const exposeOnLocalNetwork = options.exposeOnLocalNetwork === true;
   stopLocalServerMonitor();
 
-  if (!options.forceRestart && currentConnection?.mode === "local_embedded" && mainWindow && !mainWindow.isDestroyed()) {
+  if (
+    !options.forceRestart
+    && currentConnection?.mode === "local_embedded"
+    && (currentConnection.localNetworkEnabled === true) === exposeOnLocalNetwork
+    && mainWindow
+    && !mainWindow.isDestroyed()
+  ) {
     connectionStore.recordConnectionResult(LOCAL_PROFILE_ID);
+    connectionStore.setLocalNetworkEnabled(exposeOnLocalNetwork);
     if (options.rememberChoiceExplicit) {
       connectionStore.setRememberedProfile(
         LOCAL_PROFILE_ID,
@@ -928,7 +961,8 @@ async function bootLocal(options: {
     }
 
     sendBootStatus("database", "Launching embedded PostgreSQL...", 15);
-    nextServerProcess = startServer(serverPort);
+    const launch = startServer(serverPort, { exposeOnLocalNetwork });
+    nextServerProcess = launch.process;
     trackServerProcess(nextServerProcess);
 
     const logFile = path.join(app.getPath("userData"), "server.log");
@@ -1015,7 +1049,11 @@ async function bootLocal(options: {
       return;
     }
 
-    sendBootStatus("server", "Server is ready", 70);
+    sendBootStatus(
+      "server",
+      launch.localNetworkUrl ? `Server is ready at ${launch.localNetworkUrl}` : "Server is ready",
+      70,
+    );
     sendBootStatus("ready", "Loading the UI...", 80);
 
     const startUrl = `http://localhost:${serverPort}`;
@@ -1052,8 +1090,11 @@ async function bootLocal(options: {
       startUrl,
       allowedOrigin: new URL(startUrl).origin,
       partition: localPartition(),
+      localNetworkEnabled: exposeOnLocalNetwork,
+      localNetworkUrl: launch.localNetworkUrl,
     };
     connectionStore.recordConnectionResult(LOCAL_PROFILE_ID);
+    connectionStore.setLocalNetworkEnabled(exposeOnLocalNetwork);
     if (options.rememberChoiceExplicit) {
       connectionStore.setRememberedProfile(
         LOCAL_PROFILE_ID,
@@ -1222,7 +1263,10 @@ async function bootSavedProfile(
   options: { rememberChoiceExplicit?: boolean; rememberChoice?: boolean } = {},
 ): Promise<void> {
   if (profileId === LOCAL_PROFILE_ID) {
-    await bootLocal(options);
+    await bootLocal({
+      ...options,
+      exposeOnLocalNetwork: connectionStore.getSnapshot().state.localNetworkEnabled,
+    });
     return;
   }
 
@@ -1289,13 +1333,17 @@ function registerLauncherIpc(): void {
       localServerVersion: resolveLocalServerVersion(),
     }));
 
-  ipcMain.handle("launcher:connect-local", async (_event, payload: { rememberChoice: boolean }) => {
-    void bootLocal({
-      rememberChoiceExplicit: true,
-      rememberChoice: payload.rememberChoice,
-    });
-    return { started: true };
-  });
+  ipcMain.handle(
+    "launcher:connect-local",
+    async (_event, payload: { rememberChoice: boolean; exposeOnLocalNetwork?: boolean }) => {
+      void bootLocal({
+        rememberChoiceExplicit: true,
+        rememberChoice: payload.rememberChoice,
+        exposeOnLocalNetwork: payload.exposeOnLocalNetwork === true,
+      });
+      return { started: true };
+    },
+  );
 
   ipcMain.handle(
     "launcher:connect-remote",
@@ -1468,6 +1516,12 @@ function buildConnectionMenuItems(): MenuItemConstructorOptions[] {
       },
     },
     {
+      label: "Connect Local Network",
+      click: () => {
+        void ensureLauncherWindow("local-boot").then(() => bootLocal({ exposeOnLocalNetwork: true }));
+      },
+    },
+    {
       label: "Manage Connections",
       click: () => {
         void ensureLauncherWindow("saved");
@@ -1544,7 +1598,9 @@ app.whenReady().then(async () => {
   if (startupProfileId) {
     if (startupProfileId === LOCAL_PROFILE_ID) {
       await ensureLauncherWindow("local-boot");
-      void bootLocal();
+      void bootLocal({
+        exposeOnLocalNetwork: connectionStore.getSnapshot().state.localNetworkEnabled,
+      });
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -342,7 +342,6 @@ function startServer(port: number, options: { exposeOnLocalNetwork?: boolean } =
     ? buildLocalNetworkExposureConfig({
         port,
         authSecret: readOrCreateLocalNetworkAuthSecret(app.getPath("userData")),
-        baseEnv: process.env,
       })
     : null;
   if (localNetworkExposure) {

--- a/test/connection-profiles.test.mjs
+++ b/test/connection-profiles.test.mjs
@@ -50,11 +50,15 @@ test("connection store keeps a synthetic local profile", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-local-"));
   const store = new ConnectionStore(getConnectionsFilePath(tempDir));
 
+  store.setLocalNetworkEnabled(true);
   store.recordConnectionResult(LOCAL_PROFILE_ID, undefined, "2026-04-06T10:00:00.000Z");
 
   const localProfile = store.getProfile(LOCAL_PROFILE_ID);
   assert.equal(localProfile.mode, "local_embedded");
   assert.equal(localProfile.lastConnectedAt, "2026-04-06T10:00:00.000Z");
+
+  const reloaded = new ConnectionStore(getConnectionsFilePath(tempDir));
+  assert.equal(reloaded.getSnapshot().state.localNetworkEnabled, true);
 });
 
 test("connection store duplicates and deletes remote profiles", () => {

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -39,7 +39,11 @@ test("local network exposure config enables authenticated LAN mode", () => {
   assert.equal(config.env.PAPERCLIP_DEPLOYMENT_EXPOSURE, "private");
   assert.equal(config.env.PAPERCLIP_BIND, "lan");
   assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret-with-enough-entropy");
+  assert.equal(config.env.PAPERCLIP_AUTH_BASE_URL_MODE, "explicit");
   assert.equal(config.env.PAPERCLIP_PUBLIC_URL, "http://192.168.1.23:3100");
+  assert.equal(config.env.BETTER_AUTH_URL, "http://192.168.1.23:3100");
+  assert.equal(config.env.BETTER_AUTH_BASE_URL, "http://192.168.1.23:3100");
+  assert.equal(config.env.BETTER_AUTH_TRUSTED_ORIGINS, "");
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /192\.168\.1\.23/);
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip-host\.local/);
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /localhost/);
@@ -61,8 +65,10 @@ test("local network exposure excludes public-looking hostnames from allow-list",
 test("local network exposure ignores ambient public URL and host allow-list env", () => {
   const previousPublicUrl = process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
   const previousAllowedHostnames = process.env.PAPERCLIP_ALLOWED_HOSTNAMES;
+  const previousTrustedOrigins = process.env.BETTER_AUTH_TRUSTED_ORIGINS;
   process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = "https://paperclip.example.com";
   process.env.PAPERCLIP_ALLOWED_HOSTNAMES = "paperclip.example.com";
+  process.env.BETTER_AUTH_TRUSTED_ORIGINS = "https://paperclip.example.com";
 
   try {
     const config = buildLocalNetworkExposureConfig({
@@ -76,6 +82,7 @@ test("local network exposure ignores ambient public URL and host allow-list env"
     assert.equal(config.primaryUrl, "http://10.0.0.15:3100");
     assert.equal(config.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL, "http://10.0.0.15:3100");
     assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret-with-enough-entropy");
+    assert.equal(config.env.BETTER_AUTH_TRUSTED_ORIGINS, "");
     assert.doesNotMatch(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.example\.com/);
   } finally {
     if (previousPublicUrl === undefined) {
@@ -87,6 +94,11 @@ test("local network exposure ignores ambient public URL and host allow-list env"
       delete process.env.PAPERCLIP_ALLOWED_HOSTNAMES;
     } else {
       process.env.PAPERCLIP_ALLOWED_HOSTNAMES = previousAllowedHostnames;
+    }
+    if (previousTrustedOrigins === undefined) {
+      delete process.env.BETTER_AUTH_TRUSTED_ORIGINS;
+    } else {
+      process.env.BETTER_AUTH_TRUSTED_ORIGINS = previousTrustedOrigins;
     }
   }
 });

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -16,6 +16,7 @@ test("local network address detection keeps only usable external IPv4 addresses"
   const addresses = listLocalNetworkIpv4Addresses({
     lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
     en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+    en2: [{ address: "8.8.8.8", family: "IPv4", internal: false }],
     en1: [{ address: "169.254.1.10", family: "IPv4", internal: false }],
     utun: [{ address: "fd00::1", family: "IPv6", internal: false }],
   });
@@ -73,4 +74,14 @@ test("local network auth secret is stable once written", () => {
 
   assert.equal(first, second);
   assert.ok(first.length >= 32);
+});
+
+test("local network auth secret replaces weak existing values", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-lan-weak-secret-"));
+  fs.writeFileSync(path.join(tempDir, "paperclip-lan-auth-secret"), "weak\n", "utf8");
+
+  const secret = readOrCreateLocalNetworkAuthSecret(tempDir);
+
+  assert.notEqual(secret, "weak");
+  assert.ok(secret.length >= 32);
 });

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const {
+  buildLocalNetworkExposureConfig,
+  listLocalNetworkIpv4Addresses,
+  readOrCreateLocalNetworkAuthSecret,
+} = require("../dist/connection/local-network-exposure.js");
+
+test("local network address detection keeps only usable external IPv4 addresses", () => {
+  const addresses = listLocalNetworkIpv4Addresses({
+    lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
+    en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+    en1: [{ address: "169.254.1.10", family: "IPv4", internal: false }],
+    utun: [{ address: "fd00::1", family: "IPv6", internal: false }],
+  });
+
+  assert.deepEqual(addresses, ["192.168.1.23"]);
+});
+
+test("local network exposure config enables authenticated LAN mode", () => {
+  const config = buildLocalNetworkExposureConfig({
+    port: 3100,
+    authSecret: "generated-secret",
+    hostname: "Paperclip-Host.local",
+    baseEnv: {
+      PAPERCLIP_ALLOWED_HOSTNAMES: "paperclip.local",
+    },
+    interfaces: {
+      en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+    },
+  });
+
+  assert.equal(config.primaryUrl, "http://192.168.1.23:3100");
+  assert.equal(config.env.PAPERCLIP_DEPLOYMENT_MODE, "authenticated");
+  assert.equal(config.env.PAPERCLIP_DEPLOYMENT_EXPOSURE, "private");
+  assert.equal(config.env.PAPERCLIP_BIND, "lan");
+  assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret");
+  assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /192\.168\.1\.23/);
+  assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip-host\.local/);
+  assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.local/);
+  assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /localhost/);
+});
+
+test("local network exposure respects existing public auth URL and auth secret", () => {
+  const config = buildLocalNetworkExposureConfig({
+    port: 3100,
+    authSecret: "generated-secret",
+    baseEnv: {
+      PAPERCLIP_AUTH_PUBLIC_BASE_URL: "http://paperclip.lan:3200",
+      BETTER_AUTH_SECRET: "existing-secret",
+    },
+    interfaces: {
+      en0: [{ address: "10.0.0.15", family: "IPv4", internal: false }],
+    },
+  });
+
+  assert.equal(config.primaryUrl, "http://paperclip.lan:3200");
+  assert.equal(config.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL, "http://paperclip.lan:3200");
+  assert.equal(config.env.BETTER_AUTH_SECRET, "existing-secret");
+});
+
+test("local network auth secret is stable once written", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "paperclip-lan-secret-"));
+
+  const first = readOrCreateLocalNetworkAuthSecret(tempDir);
+  const second = readOrCreateLocalNetworkAuthSecret(tempDir);
+
+  assert.equal(first, second);
+  assert.ok(first.length >= 32);
+});

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -45,6 +45,19 @@ test("local network exposure config enables authenticated LAN mode", () => {
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /localhost/);
 });
 
+test("local network exposure excludes public-looking hostnames from allow-list", () => {
+  const config = buildLocalNetworkExposureConfig({
+    port: 3100,
+    authSecret: "generated-secret-with-enough-entropy",
+    hostname: "paperclip.example.com",
+    interfaces: {
+      en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+    },
+  });
+
+  assert.doesNotMatch(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.example\.com/);
+});
+
 test("local network exposure ignores ambient public URL and host allow-list env", () => {
   const previousPublicUrl = process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
   const previousAllowedHostnames = process.env.PAPERCLIP_ALLOWED_HOSTNAMES;

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -27,11 +27,8 @@ test("local network address detection keeps only usable external IPv4 addresses"
 test("local network exposure config enables authenticated LAN mode", () => {
   const config = buildLocalNetworkExposureConfig({
     port: 3100,
-    authSecret: "generated-secret",
+    authSecret: "generated-secret-with-enough-entropy",
     hostname: "Paperclip-Host.local",
-    baseEnv: {
-      PAPERCLIP_ALLOWED_HOSTNAMES: "paperclip.local",
-    },
     interfaces: {
       en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
     },
@@ -41,29 +38,44 @@ test("local network exposure config enables authenticated LAN mode", () => {
   assert.equal(config.env.PAPERCLIP_DEPLOYMENT_MODE, "authenticated");
   assert.equal(config.env.PAPERCLIP_DEPLOYMENT_EXPOSURE, "private");
   assert.equal(config.env.PAPERCLIP_BIND, "lan");
-  assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret");
+  assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret-with-enough-entropy");
+  assert.equal(config.env.PAPERCLIP_PUBLIC_URL, "http://192.168.1.23:3100");
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /192\.168\.1\.23/);
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip-host\.local/);
-  assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.local/);
   assert.match(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /localhost/);
 });
 
-test("local network exposure respects existing public auth URL and auth secret", () => {
-  const config = buildLocalNetworkExposureConfig({
-    port: 3100,
-    authSecret: "generated-secret",
-    baseEnv: {
-      PAPERCLIP_AUTH_PUBLIC_BASE_URL: "http://paperclip.lan:3200",
-      BETTER_AUTH_SECRET: "existing-secret",
-    },
-    interfaces: {
-      en0: [{ address: "10.0.0.15", family: "IPv4", internal: false }],
-    },
-  });
+test("local network exposure ignores ambient public URL and host allow-list env", () => {
+  const previousPublicUrl = process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
+  const previousAllowedHostnames = process.env.PAPERCLIP_ALLOWED_HOSTNAMES;
+  process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = "https://paperclip.example.com";
+  process.env.PAPERCLIP_ALLOWED_HOSTNAMES = "paperclip.example.com";
 
-  assert.equal(config.primaryUrl, "http://paperclip.lan:3200");
-  assert.equal(config.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL, "http://paperclip.lan:3200");
-  assert.equal(config.env.BETTER_AUTH_SECRET, "existing-secret");
+  try {
+    const config = buildLocalNetworkExposureConfig({
+      port: 3100,
+      authSecret: "generated-secret-with-enough-entropy",
+      interfaces: {
+        en0: [{ address: "10.0.0.15", family: "IPv4", internal: false }],
+      },
+    });
+
+    assert.equal(config.primaryUrl, "http://10.0.0.15:3100");
+    assert.equal(config.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL, "http://10.0.0.15:3100");
+    assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret-with-enough-entropy");
+    assert.doesNotMatch(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.example\.com/);
+  } finally {
+    if (previousPublicUrl === undefined) {
+      delete process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
+    } else {
+      process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL = previousPublicUrl;
+    }
+    if (previousAllowedHostnames === undefined) {
+      delete process.env.PAPERCLIP_ALLOWED_HOSTNAMES;
+    } else {
+      process.env.PAPERCLIP_ALLOWED_HOSTNAMES = previousAllowedHostnames;
+    }
+  }
 });
 
 test("local network auth secret is stable once written", () => {

--- a/test/local-network-exposure.test.mjs
+++ b/test/local-network-exposure.test.mjs
@@ -16,12 +16,27 @@ test("local network address detection keeps only usable external IPv4 addresses"
   const addresses = listLocalNetworkIpv4Addresses({
     lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
     en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+    en3: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
     en2: [{ address: "8.8.8.8", family: "IPv4", internal: false }],
     en1: [{ address: "169.254.1.10", family: "IPv4", internal: false }],
+    cgnat: [{ address: "100.64.1.10", family: "IPv4", internal: false }],
     utun: [{ address: "fd00::1", family: "IPv6", internal: false }],
   });
 
   assert.deepEqual(addresses, ["192.168.1.23"]);
+});
+
+test("local network address detection accepts RFC1918 ranges only", () => {
+  const addresses = listLocalNetworkIpv4Addresses({
+    ten: [{ address: "10.0.0.9", family: "IPv4", internal: false }],
+    "172low": [{ address: "172.15.255.255", family: "IPv4", internal: false }],
+    "172start": [{ address: "172.16.0.1", family: "IPv4", internal: false }],
+    "172end": [{ address: "172.31.255.254", family: "IPv4", internal: false }],
+    "172high": [{ address: "172.32.0.1", family: "IPv4", internal: false }],
+    lan: [{ address: "192.168.0.5", family: "IPv4", internal: false }],
+  });
+
+  assert.deepEqual(addresses, ["10.0.0.9", "172.16.0.1", "172.31.255.254", "192.168.0.5"]);
 });
 
 test("local network exposure config enables authenticated LAN mode", () => {
@@ -84,6 +99,12 @@ test("local network exposure ignores ambient public URL and host allow-list env"
     assert.equal(config.env.BETTER_AUTH_SECRET, "generated-secret-with-enough-entropy");
     assert.equal(config.env.BETTER_AUTH_TRUSTED_ORIGINS, "");
     assert.doesNotMatch(config.env.PAPERCLIP_ALLOWED_HOSTNAMES, /paperclip\.example\.com/);
+    assert.deepEqual(
+      Object.entries(config.env)
+        .filter(([, value]) => value.includes("paperclip.example.com"))
+        .map(([key]) => key),
+      [],
+    );
   } finally {
     if (previousPublicUrl === undefined) {
       delete process.env.PAPERCLIP_AUTH_PUBLIC_BASE_URL;
@@ -101,6 +122,32 @@ test("local network exposure ignores ambient public URL and host allow-list env"
       process.env.BETTER_AUTH_TRUSTED_ORIGINS = previousTrustedOrigins;
     }
   }
+});
+
+test("local network exposure rejects missing private addresses", () => {
+  assert.throws(
+    () => buildLocalNetworkExposureConfig({
+      port: 3100,
+      authSecret: "generated-secret-with-enough-entropy",
+      interfaces: {
+        en0: [{ address: "8.8.8.8", family: "IPv4", internal: false }],
+      },
+    }),
+    /No active IPv4 local network address/,
+  );
+});
+
+test("local network exposure rejects weak auth secrets", () => {
+  assert.throws(
+    () => buildLocalNetworkExposureConfig({
+      port: 3100,
+      authSecret: "too-short",
+      interfaces: {
+        en0: [{ address: "192.168.1.23", family: "IPv4", internal: false }],
+      },
+    }),
+    /requires an auth secret/,
+  );
 });
 
 test("local network auth secret is stable once written", () => {

--- a/test/local-port-selection.test.mjs
+++ b/test/local-port-selection.test.mjs
@@ -1,0 +1,62 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import net from "node:net";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const {
+  bindHostForLocalExposure,
+  findFreePortForHost,
+  isPortAvailableForHost,
+} = require("../dist/connection/local-port-selection.js");
+
+test("local port selection maps exposure mode to the bind host", () => {
+  assert.equal(bindHostForLocalExposure(false), "127.0.0.1");
+  assert.equal(bindHostForLocalExposure(true), "0.0.0.0");
+});
+
+test("local port selection checks availability on the requested bind host", async () => {
+  const occupied = await listenOnRandomPort("0.0.0.0");
+  try {
+    assert.equal(await isPortAvailableForHost(occupied.port, "0.0.0.0"), false);
+  } finally {
+    await closeServer(occupied.server);
+  }
+});
+
+test("local port selection skips occupied ports", async () => {
+  const occupied = await listenOnRandomPort("127.0.0.1");
+  try {
+    const selected = await findFreePortForHost(occupied.port, "127.0.0.1", 2);
+    assert.equal(selected, occupied.port + 1);
+  } finally {
+    await closeServer(occupied.server);
+  }
+});
+
+function listenOnRandomPort(host) {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen({ port: 0, host }, () => {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Expected TCP server address."));
+        return;
+      }
+      resolve({ server, port: address.port });
+    });
+  });
+}
+
+function closeServer(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}

--- a/test/local-server-lifecycle.test.mjs
+++ b/test/local-server-lifecycle.test.mjs
@@ -8,6 +8,7 @@ const {
   shouldHandleTrackedServerExit,
   shouldKillSupersededServer,
   shouldRestorePreviousTrackedServer,
+  shouldStopPreviousLocalServerForExposureChange,
   shouldStopAttemptedServer,
 } = require("../dist/connection/local-server-lifecycle.js");
 
@@ -38,4 +39,27 @@ test("local server lifecycle restores the previous process after a failed replac
   assert.equal(shouldStopAttemptedServer(attempted, attempted), true);
   assert.equal(shouldRestorePreviousTrackedServer(previous, attempted, attempted), true);
   assert.equal(shouldRestorePreviousTrackedServer(null, attempted, attempted), false);
+});
+
+test("local server lifecycle stops previous server when local exposure changes", () => {
+  assert.equal(shouldStopPreviousLocalServerForExposureChange({
+    previousMode: "local_embedded",
+    currentExposeOnLocalNetwork: false,
+    nextExposeOnLocalNetwork: true,
+  }), true);
+  assert.equal(shouldStopPreviousLocalServerForExposureChange({
+    previousMode: "local_embedded",
+    currentExposeOnLocalNetwork: true,
+    nextExposeOnLocalNetwork: false,
+  }), true);
+  assert.equal(shouldStopPreviousLocalServerForExposureChange({
+    previousMode: "local_embedded",
+    currentExposeOnLocalNetwork: true,
+    nextExposeOnLocalNetwork: true,
+  }), false);
+  assert.equal(shouldStopPreviousLocalServerForExposureChange({
+    previousMode: "remote_existing",
+    currentExposeOnLocalNetwork: false,
+    nextExposeOnLocalNetwork: true,
+  }), false);
 });


### PR DESCRIPTION
## Summary

Adds an explicit launcher option to share the embedded local Paperclip server on the local network while keeping the default local mode loopback-only.

## What changed

- Added a `Share on local network` option in the local launcher flow.
- Starts upstream Paperclip in authenticated LAN mode when sharing is enabled.
- Generates and persists a strong Desktop-owned auth secret for LAN mode.
- Restricts LAN address selection to RFC1918 IPv4 addresses and avoids public-looking hostnames in the allow-list.
- Pins Paperclip and Better Auth public/auth origin env to the selected LAN URL and clears inherited trusted-origin env.
- Stops the previous embedded local server before switching between loopback and LAN modes.
- Adds connection and local-network exposure tests.
- Documents the LAN sharing behavior and firewall caveat.

## Validation

- `pnpm test:connections` passed: 43 tests.
- `pnpm build` passed after final scan.
- `git diff --check` passed.

## Notes

LAN sharing is still HTTP on a trusted local network. It requires sign-in and may require the host firewall to allow incoming connections.