### PR TITLE
[codex] fix LAN port collisions

### DIFF
--- a/src/connection/local-port-selection.ts
+++ b/src/connection/local-port-selection.ts
@@ -6,6 +6,10 @@ export function bindHostForLocalExposure(exposeOnLocalNetwork: boolean): LocalSe
   return exposeOnLocalNetwork ? "0.0.0.0" : "127.0.0.1";
 }
 
+export function bindHostsForLocalExposure(exposeOnLocalNetwork: boolean): LocalServerBindHost[] {
+  return exposeOnLocalNetwork ? ["0.0.0.0", "127.0.0.1"] : ["127.0.0.1"];
+}
+
 export function isPortAvailableForHost(port: number, host: LocalServerBindHost): Promise<boolean> {
   return new Promise((resolve) => {
     const server = net.createServer();
@@ -26,6 +30,19 @@ export function isPortAvailableForHost(port: number, host: LocalServerBindHost):
   });
 }
 
+export async function isPortAvailableForLocalExposure(
+  port: number,
+  exposeOnLocalNetwork: boolean,
+): Promise<boolean> {
+  for (const host of bindHostsForLocalExposure(exposeOnLocalNetwork)) {
+    if (!(await isPortAvailableForHost(port, host))) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 export async function findFreePortForHost(
   startPort: number,
   host: LocalServerBindHost,
@@ -38,4 +55,19 @@ export async function findFreePortForHost(
   }
 
   throw new Error(`No free port found on ${host} in range ${startPort}-${startPort + maxAttempts - 1}`);
+}
+
+export async function findFreePortForLocalExposure(
+  startPort: number,
+  exposeOnLocalNetwork: boolean,
+  maxAttempts = 100,
+): Promise<number> {
+  for (let port = startPort; port < startPort + maxAttempts; port += 1) {
+    if (await isPortAvailableForLocalExposure(port, exposeOnLocalNetwork)) {
+      return port;
+    }
+  }
+
+  const hosts = bindHostsForLocalExposure(exposeOnLocalNetwork).join(", ");
+  throw new Error(`No free port found on ${hosts} in range ${startPort}-${startPort + maxAttempts - 1}`);
 }

--- a/src/connection/local-port-selection.ts
+++ b/src/connection/local-port-selection.ts
@@ -7,7 +7,7 @@ export function bindHostForLocalExposure(exposeOnLocalNetwork: boolean): LocalSe
 }
 
 export function bindHostsForLocalExposure(exposeOnLocalNetwork: boolean): LocalServerBindHost[] {
-  return exposeOnLocalNetwork ? ["0.0.0.0", "127.0.0.1"] : ["127.0.0.1"];
+  return exposeOnLocalNetwork ? ["0.0.0.0", "127.0.0.1"] : ["127.0.0.1", "0.0.0.0"];
 }
 
 export function isPortAvailableForHost(port: number, host: LocalServerBindHost): Promise<boolean> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,6 @@ import {
 import { execSync, spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
-import net from "node:net";
 import path from "node:path";
 import treeKill from "tree-kill";
 import { checkForUpdatesFromMenu, initAutoUpdater } from "./updater";
@@ -34,8 +33,7 @@ import {
   readOrCreateLocalNetworkAuthSecret,
 } from "./connection/local-network-exposure";
 import {
-  bindHostForLocalExposure,
-  findFreePortForHost,
+  findFreePortForLocalExposure,
 } from "./connection/local-port-selection";
 import { preflightRemoteConnection } from "./connection/preflight";
 import { ConnectionStore, getConnectionsFilePath } from "./connection/profiles";
@@ -160,27 +158,53 @@ function ensureLauncherHtmlFile(): string {
 // Port detection and server lifecycle
 // ---------------------------------------------------------------------------
 
-function waitForPort(port: number, timeoutMs: number): Promise<void> {
+function waitWithTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(message));
+    }, timeoutMs);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+function waitForLocalServerHealth(origin: string, timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + timeoutMs;
+    let lastDetail = "Local server health check did not complete.";
 
-    const tryConnect = () => {
-      if (Date.now() > deadline) {
-        reject(new Error(`Server did not start within ${timeoutMs}ms`));
+    const poll = async () => {
+      const remainingMs = deadline - Date.now();
+      if (remainingMs <= 0) {
+        reject(new Error(`Local server did not become healthy within ${timeoutMs}ms. ${lastDetail}`));
         return;
       }
 
-      const sock = net.createConnection({ port, host: "127.0.0.1" }, () => {
-        sock.destroy();
+      const result = await probeLocalServerHealth({
+        origin,
+        timeoutMs: Math.min(LOCAL_SERVER_HEALTH_TIMEOUT_MS, Math.max(1_000, remainingMs)),
+      });
+      if (result.ok) {
         resolve();
-      });
+        return;
+      }
 
-      sock.on("error", () => {
-        setTimeout(tryConnect, POLL_INTERVAL_MS);
-      });
+      lastDetail = result.detail ?? "Local server health check failed.";
+      setTimeout(() => {
+        void poll();
+      }, POLL_INTERVAL_MS);
     };
 
-    tryConnect();
+    void poll();
   });
 }
 
@@ -946,7 +970,7 @@ async function bootLocal(options: {
   try {
     sendBootStatus("init", "Preparing environment...", 5);
 
-    serverPort = await findFreePortForHost(PREFERRED_PORT, bindHostForLocalExposure(exposeOnLocalNetwork));
+    serverPort = await findFreePortForLocalExposure(PREFERRED_PORT, exposeOnLocalNetwork);
     if (bootId !== bootSequence) {
       return;
     }
@@ -964,6 +988,12 @@ async function bootLocal(options: {
     const launch = startServer(serverPort, { exposeOnLocalNetwork });
     nextServerProcess = launch.process;
     trackServerProcess(nextServerProcess);
+    let resolveServerListening: (() => void) | null = null;
+    let rejectServerListening: ((error: Error) => void) | null = null;
+    const serverListeningPromise = new Promise<void>((resolve, reject) => {
+      resolveServerListening = resolve;
+      rejectServerListening = reject;
+    });
 
     const logFile = path.join(app.getPath("userData"), "server.log");
     const logStream = fs.createWriteStream(logFile, { flags: "a" });
@@ -997,6 +1027,9 @@ async function bootLocal(options: {
 
       if (!serverListening && text.includes("Server listening on")) {
         serverListening = true;
+        resolveServerListening?.();
+        resolveServerListening = null;
+        rejectServerListening = null;
         updateProgress("server", "Server is starting...", 55);
       }
     };
@@ -1014,6 +1047,11 @@ async function bootLocal(options: {
       stopLocalServerMonitor();
       const tail = serverOutputLines.slice(-30).join("\n");
       console.error(`Server exited unexpectedly (code=${code}, signal=${signal})\n${tail}`);
+      if (!serverListening) {
+        rejectServerListening?.(new Error(`Server exited before listening (code=${code}, signal=${signal}).\n${tail}`));
+        resolveServerListening = null;
+        rejectServerListening = null;
+      }
       void promptToRecoverLocalServer({
         message: "The embedded Paperclip server stopped unexpectedly.",
         detail: `Exit code: ${code}, signal: ${signal}\n\nLog: ${logFile}\n\n${tail}`,
@@ -1034,8 +1072,17 @@ async function bootLocal(options: {
     }, 2_000);
 
     updateProgress("server", "Waiting for server...", 45);
-    await waitForPort(serverPort, SERVER_STARTUP_TIMEOUT_MS);
-    clearInterval(progressInterval);
+    const startUrl = `http://localhost:${serverPort}`;
+    try {
+      await waitWithTimeout(
+        serverListeningPromise,
+        SERVER_STARTUP_TIMEOUT_MS,
+        `Server did not report listening within ${SERVER_STARTUP_TIMEOUT_MS}ms`,
+      );
+      await waitForLocalServerHealth(new URL(startUrl).origin, SERVER_STARTUP_TIMEOUT_MS);
+    } finally {
+      clearInterval(progressInterval);
+    }
 
     if (bootId !== bootSequence) {
       if (shouldStopAttemptedServer(nextServerProcess, serverProcess)) {
@@ -1056,7 +1103,6 @@ async function bootLocal(options: {
     );
     sendBootStatus("ready", "Loading the UI...", 80);
 
-    const startUrl = `http://localhost:${serverPort}`;
     const window = createMainWindow({
       mode: "local_embedded",
       startUrl,

--- a/src/main.ts
+++ b/src/main.ts
@@ -343,7 +343,10 @@ function resolvePaperclipHome(): string {
   });
 }
 
-function startServer(port: number, options: { exposeOnLocalNetwork?: boolean } = {}): LocalServerLaunch {
+function startServer(port: number, options: {
+  exposeOnLocalNetwork?: boolean;
+  onOutput?: (chunk: Buffer) => void;
+} = {}): LocalServerLaunch {
   const root = getAppRoot();
   const isWindows = process.platform === "win32";
   const enrichedPath = resolveShellPath();
@@ -391,8 +394,14 @@ function startServer(port: number, options: { exposeOnLocalNetwork?: boolean } =
     writePidFile(child.pid);
   }
 
-  child.stdout?.on("data", (chunk: Buffer) => process.stdout.write(chunk));
-  child.stderr?.on("data", (chunk: Buffer) => process.stderr.write(chunk));
+  child.stdout?.on("data", (chunk: Buffer) => {
+    process.stdout.write(chunk);
+    options.onOutput?.(chunk);
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    process.stderr.write(chunk);
+    options.onOutput?.(chunk);
+  });
   return {
     process: child,
     localNetworkUrl: localNetworkExposure?.primaryUrl,
@@ -985,9 +994,6 @@ async function bootLocal(options: {
       previousServerProcess = null;
     }
 
-    const launch = startServer(serverPort, { exposeOnLocalNetwork });
-    nextServerProcess = launch.process;
-    trackServerProcess(nextServerProcess);
     let resolveServerListening: (() => void) | null = null;
     let rejectServerListening: ((error: Error) => void) | null = null;
     const serverListeningPromise = new Promise<void>((resolve, reject) => {
@@ -1034,8 +1040,9 @@ async function bootLocal(options: {
       }
     };
 
-    nextServerProcess.stdout?.on("data", onServerData);
-    nextServerProcess.stderr?.on("data", onServerData);
+    const launch = startServer(serverPort, { exposeOnLocalNetwork, onOutput: onServerData });
+    nextServerProcess = launch.process;
+    trackServerProcess(nextServerProcess);
 
     nextServerProcess.on("exit", (code, signal) => {
       logStream.end();

--- a/test/local-port-selection.test.mjs
+++ b/test/local-port-selection.test.mjs
@@ -6,13 +6,18 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const {
   bindHostForLocalExposure,
+  bindHostsForLocalExposure,
+  findFreePortForLocalExposure,
   findFreePortForHost,
+  isPortAvailableForLocalExposure,
   isPortAvailableForHost,
 } = require("../dist/connection/local-port-selection.js");
 
 test("local port selection maps exposure mode to the bind host", () => {
   assert.equal(bindHostForLocalExposure(false), "127.0.0.1");
   assert.equal(bindHostForLocalExposure(true), "0.0.0.0");
+  assert.deepEqual(bindHostsForLocalExposure(false), ["127.0.0.1"]);
+  assert.deepEqual(bindHostsForLocalExposure(true), ["0.0.0.0", "127.0.0.1"]);
 });
 
 test("local port selection checks availability on the requested bind host", async () => {
@@ -28,6 +33,18 @@ test("local port selection skips occupied ports", async () => {
   const occupied = await listenOnRandomPort("127.0.0.1");
   try {
     const selected = await findFreePortForHost(occupied.port, "127.0.0.1", 2);
+    assert.equal(selected, occupied.port + 1);
+  } finally {
+    await closeServer(occupied.server);
+  }
+});
+
+test("local network port selection skips ports occupied on localhost", async () => {
+  const occupied = await listenOnRandomPort("127.0.0.1");
+  try {
+    assert.equal(await isPortAvailableForLocalExposure(occupied.port, true), false);
+
+    const selected = await findFreePortForLocalExposure(occupied.port, true, 2);
     assert.equal(selected, occupied.port + 1);
   } finally {
     await closeServer(occupied.server);

--- a/test/local-port-selection.test.mjs
+++ b/test/local-port-selection.test.mjs
@@ -16,7 +16,7 @@ const {
 test("local port selection maps exposure mode to the bind host", () => {
   assert.equal(bindHostForLocalExposure(false), "127.0.0.1");
   assert.equal(bindHostForLocalExposure(true), "0.0.0.0");
-  assert.deepEqual(bindHostsForLocalExposure(false), ["127.0.0.1"]);
+  assert.deepEqual(bindHostsForLocalExposure(false), ["127.0.0.1", "0.0.0.0"]);
   assert.deepEqual(bindHostsForLocalExposure(true), ["0.0.0.0", "127.0.0.1"]);
 });
 
@@ -45,6 +45,18 @@ test("local network port selection skips ports occupied on localhost", async () 
     assert.equal(await isPortAvailableForLocalExposure(occupied.port, true), false);
 
     const selected = await findFreePortForLocalExposure(occupied.port, true, 2);
+    assert.equal(selected, occupied.port + 1);
+  } finally {
+    await closeServer(occupied.server);
+  }
+});
+
+test("private local port selection skips ports occupied on all interfaces", async () => {
+  const occupied = await listenOnRandomPort("0.0.0.0");
+  try {
+    assert.equal(await isPortAvailableForLocalExposure(occupied.port, false), false);
+
+    const selected = await findFreePortForLocalExposure(occupied.port, false, 2);
     assert.equal(selected, occupied.port + 1);
   } finally {
     await closeServer(occupied.server);


### PR DESCRIPTION
## Summary

Fixes the LAN exposure startup path so it no longer reuses port 3100 when another local Paperclip process is already bound on localhost.

## Root Cause

LAN mode selected ports by probing only the LAN bind host (`0.0.0.0`). On macOS, a port can appear available for `0.0.0.0` even when `127.0.0.1:<port>` is already occupied. The desktop UI still loads `http://localhost:<port>`, so it could connect to the older local process while the LAN process also tried to advertise the same port.

## Changes

- Add local exposure-aware port selection that requires LAN ports to be available on both `0.0.0.0` and `127.0.0.1`.
- Use that exposure-aware selection in the embedded local boot path.
- Replace the raw TCP startup wait with a wait for the launched server process to emit its listening line, then confirm `/api/health` is healthy.
- Add regression coverage for the localhost collision case.

## Validation

- `pnpm build`
- `node --test test/local-port-selection.test.mjs test/local-server-health.test.mjs test/local-server-lifecycle.test.mjs`
- `pnpm test:connections`