### PR TITLE
fix: pin embedded-postgres to PG17 and add Docker-to-Desktop migration guide

### DIFF
--- a/docs/guides/docker-to-desktop-migration.md
+++ b/docs/guides/docker-to-desktop-migration.md
@@ -1,0 +1,182 @@
+# Migrating from Paperclip Docker to Paperclip Desktop
+
+This guide covers how to move your existing Paperclip Docker installation to
+Paperclip Desktop while keeping all your data (agents, companies, issues, runs).
+
+## Overview
+
+The Paperclip Docker deployment uses a PostgreSQL container initialized on
+Linux. Paperclip Desktop uses an embedded PostgreSQL instance initialized on
+macOS. While both use the same PostgreSQL version and data format, Linux and
+macOS represent the same locale differently:
+
+| Platform | Locale format |
+|----------|--------------|
+| Linux (Docker) | `en_US.utf8` |
+| macOS (Desktop) | `en_US.UTF-8` |
+
+PostgreSQL stores the locale at initialization time and validates it at every
+startup. Pointing Desktop directly at a Docker data directory will fail with:
+
+```
+FATAL: configuration file "postgresql.conf" contains errors
+LOG:  invalid value for parameter "lc_messages": "en_US.utf8"
+```
+
+or after that is fixed:
+
+```
+PostgresError: database locale is incompatible with operating system
+detail: The database was initialized with LC_COLLATE "en_US.utf8",
+        which is not recognized by setlocale().
+```
+
+The `postgresql.conf` issue is automatically fixed by Paperclip Desktop since
+[paperclipai/paperclip#7894](https://github.com/paperclipai/paperclip/pull/7894).
+The `LC_COLLATE` issue in the database catalog requires a one-time
+`pg_dump` / `pg_restore` migration (described below).
+
+---
+
+## Prerequisites
+
+- Paperclip Desktop installed
+- Docker running with your existing Paperclip stack
+- `pg_dump` and `pg_restore` available (`brew install libpq`)
+
+---
+
+## Migration steps
+
+### 1. Back up your data
+
+```bash
+# Duplicate the Docker postgres data directory as a safety net
+cp -r ~/Coding/paperclip/data/postgres \
+      ~/Coding/paperclip/data/postgres.bak-$(date +%Y%m%d-%H%M)
+```
+
+### 2. Dump your database from Docker
+
+```bash
+# Dump in custom format (compressed, supports selective restore)
+docker exec paperclip-local-db-1 \
+  pg_dump -U paperclip -d paperclip -Fc -f /tmp/paperclip.pgdump
+
+# Copy the dump to your host
+docker cp paperclip-local-db-1:/tmp/paperclip.pgdump \
+  ~/Coding/paperclip/data/paperclip.pgdump
+```
+
+### 3. Stop Docker
+
+```bash
+cd ~/Coding/paperclip && docker compose stop
+```
+
+### 4. Move the old data directory aside
+
+```bash
+mv ~/Coding/paperclip/data/postgres \
+   ~/Coding/paperclip/data/postgres.linux-$(date +%Y%m%d-%H%M)
+mkdir ~/Coding/paperclip/data/postgres
+```
+
+### 5. Configure Paperclip Desktop
+
+Edit `~/.paperclip/instances/default/config.json`:
+
+```json
+{
+  "database": {
+    "mode": "embedded-postgres",
+    "embeddedPostgresDataDir": "/Users/<you>/Coding/paperclip/data/postgres",
+    "embeddedPostgresPort": 54352
+  }
+}
+```
+
+Add to `~/.paperclip/instances/default/.env`:
+
+```
+PAPERCLIP_HOME=/Users/<you>/Coding/paperclip/data/paperclip
+```
+
+### 6. Let Desktop initialize the new cluster
+
+Start Paperclip Desktop once. It will initialize a fresh PostgreSQL cluster
+with macOS-compatible locales and then fail to find any data — that is expected.
+Close Desktop again after it shows the UI (or after seeing "Server listening"
+in the log).
+
+```bash
+# Confirm the new cluster was initialized
+cat ~/Coding/paperclip/data/postgres/PG_VERSION   # should print: 17
+```
+
+### 7. Restore your data
+
+```bash
+# Start the embedded postgres directly for the restore
+PG_BIN="/Applications/Paperclip Desktop.app/Contents/Resources/app-server/server/node_modules/@embedded-postgres/darwin-arm64/native/bin"
+DATA="$HOME/Coding/paperclip/data/postgres"
+
+"$PG_BIN/pg_ctl" -D "$DATA" -o "-p 54352" start -w
+
+# Create the database and restore
+/opt/homebrew/opt/libpq/bin/createdb \
+  -h 127.0.0.1 -p 54352 -U paperclip paperclip
+
+/opt/homebrew/opt/libpq/bin/pg_restore \
+  -h 127.0.0.1 -p 54352 -U paperclip -d paperclip \
+  --no-owner --no-privileges \
+  ~/Coding/paperclip/data/paperclip.pgdump
+
+# Stop postgres — Desktop will manage it from here
+"$PG_BIN/pg_ctl" -D "$DATA" stop
+```
+
+### 8. Start Paperclip Desktop
+
+All your agents, companies, issues, and runs are now available natively on
+macOS — no Docker required.
+
+---
+
+## Keeping Docker available as a fallback
+
+The old data directory is preserved at `postgres.linux-<timestamp>`. If you
+need to roll back:
+
+```bash
+# Stop Desktop, restore the old directory, restart Docker
+mv ~/Coding/paperclip/data/postgres \
+   ~/Coding/paperclip/data/postgres.macos-rollback
+mv ~/Coding/paperclip/data/postgres.linux-<timestamp> \
+   ~/Coding/paperclip/data/postgres
+cd ~/Coding/paperclip && docker compose up -d
+```
+
+---
+
+## Keeping Docker DB as the backend (alternative)
+
+If you prefer to keep Docker running and just use Desktop as the UI, configure
+Desktop to connect to the Docker Postgres directly:
+
+`~/.paperclip/instances/default/config.json`:
+```json
+{
+  "database": {
+    "mode": "postgres",
+    "connectionString": "postgres://paperclip:<password>@localhost:54352/paperclip"
+  }
+}
+```
+
+`~/.paperclip/instances/default/.env`:
+```
+DATABASE_URL=postgres://paperclip:<password>@localhost:54352/paperclip
+```
+
+In this case Docker DB must be running whenever you use Desktop.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paperclip-desktop",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "private": true,
   "description": "Paperclip desktop application — Electron wrapper for the Paperclip server",
   "author": {
@@ -36,7 +36,7 @@
     "tree-kill": "^1.2.2"
   },
   "devDependencies": {
-    "@paperclipai/server": "2026.529.0",
+    "@paperclipai/server": "2026.609.0",
     "electron": "^41.5.0",
     "electron-builder": "^26.8.1",
     "typescript": "^5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         version: 1.2.2
     devDependencies:
       '@paperclipai/server':
-        specifier: 2026.529.0
-        version: 2026.529.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+        specifier: 2026.609.0
+        version: 2026.609.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       electron:
         specifier: ^41.5.0
         version: 41.5.0
@@ -379,33 +379,38 @@ packages:
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
     engines: {node: '>=20.19.0'}
 
-  '@cursor/sdk-darwin-arm64@1.0.12':
-    resolution: {integrity: sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==}
+  '@cursor/sdk-darwin-arm64@1.0.18':
+    resolution: {integrity: sha512-gXfNz+n3uf2hWCUcSdU/gBYT7TFlWwJjZAAjXFzBJ3jGu+l7ShQRa9QI2sEKvPNRtUMC/18EcQ26ks1o261Bnw==}
     cpu: [arm64]
     os: [darwin]
+    hasBin: true
 
-  '@cursor/sdk-darwin-x64@1.0.12':
-    resolution: {integrity: sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==}
+  '@cursor/sdk-darwin-x64@1.0.18':
+    resolution: {integrity: sha512-nzcPqCvPPnYsuz21olPgandVgGUzDZkHN4cUls4ukm7mddp6XqujFJv8lh9qKmVefl0/3UL2R6GFANggjwifnA==}
     cpu: [x64]
     os: [darwin]
+    hasBin: true
 
-  '@cursor/sdk-linux-arm64@1.0.12':
-    resolution: {integrity: sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==}
+  '@cursor/sdk-linux-arm64@1.0.18':
+    resolution: {integrity: sha512-MJyhVryN+0czP48SgMak/KA9xGneQ/gdsnDk1ZTJF+LemaFc+Tv7P1GT80h+3JBfu69kPyIX4epJVjroTMoFEA==}
     cpu: [arm64]
     os: [linux]
+    hasBin: true
 
-  '@cursor/sdk-linux-x64@1.0.12':
-    resolution: {integrity: sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==}
+  '@cursor/sdk-linux-x64@1.0.18':
+    resolution: {integrity: sha512-IaJqcKtXxtQEdPxivQjDWbvynw3UX31V8RdagcZ6RgHOo+B/i/P95D8svSNC4V9nbTHwVbNGfIDQ5S64gMS2hg==}
     cpu: [x64]
     os: [linux]
+    hasBin: true
 
-  '@cursor/sdk-win32-x64@1.0.12':
-    resolution: {integrity: sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==}
+  '@cursor/sdk-win32-x64@1.0.18':
+    resolution: {integrity: sha512-iqcGt1l/3xgnaT+PotY3237oyK3VnOZHtjUxSRP3Q7ahjaqsZVTnCwwljj+nal8ouvXidBHnxQLqGMSC2G6LTg==}
     cpu: [x64]
     os: [win32]
+    hasBin: true
 
-  '@cursor/sdk@1.0.12':
-    resolution: {integrity: sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==}
+  '@cursor/sdk@1.0.18':
+    resolution: {integrity: sha512-ha5EGHliMuTNuAqnPHzKFNnND4y6erddTqtxwIt9/p8ER+QsmMoRcP38PwA2sXfZnGvIBiozveBZqa4XwUddCw==}
     engines: {node: '>=18'}
 
   '@develar/schema-utils@2.6.5':
@@ -875,44 +880,44 @@ packages:
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
 
-  '@paperclipai/adapter-acpx-local@2026.529.0':
-    resolution: {integrity: sha512-JCMVgmXLHViKTFzW+2RS9eqLG02G3se5Fc63p5TtjbWnIrCzN9VoPjhOHfSvMYEhOV1yHxRJcWEqWK7VRTpFnQ==}
+  '@paperclipai/adapter-acpx-local@2026.609.0':
+    resolution: {integrity: sha512-A2XyBq42Uq5hGQbzLjhuS9b3gTqb8ABiKERIh3gnmRUH6tFbsBg+rdWNyXIR7dSNmYwkBW2TOddmZpdrI6gdMA==}
 
-  '@paperclipai/adapter-claude-local@2026.529.0':
-    resolution: {integrity: sha512-zp4ZRndrz/C2k2Cn6WY3a7oqEpZx5NA1w+wF8Me4wVWZwyShzipkfPhfQA27ldycE9y4/+cN+ny8WJyzn0Pl/Q==}
+  '@paperclipai/adapter-claude-local@2026.609.0':
+    resolution: {integrity: sha512-VNWM/wfYTWNdyw1AdYyzkUe6DM4ZM2WfVBlpMOI2abdX1JNUfv2t/TMsZnulkLpIRWsvpsh7NoEyn5BX2vGUTQ==}
 
-  '@paperclipai/adapter-codex-local@2026.529.0':
-    resolution: {integrity: sha512-4DGZaT/jKVZYanKevZYoWSR9HkPw2pa8EbvGlnS55d5f5u/Vcw9VSspD22zz9sND3cdqRnLY/mxznEt+m3T/Hg==}
+  '@paperclipai/adapter-codex-local@2026.609.0':
+    resolution: {integrity: sha512-2uY5jAuKH3d0CvPnoNfi5wayRW1ndzS4HWg1Ewp/m8R2l6hat5wI/hu28jlchQKYrw8HQwltGGXmADqoFEM5yw==}
 
-  '@paperclipai/adapter-cursor-cloud@2026.529.0':
-    resolution: {integrity: sha512-pfYkjZ+cCwufZ/RLhReHvuh9BjrKFkVmvWNdXlVySLUjuGSV+Gq5EThwu75xJsMrgwzJvThfg8ILyovKliN9Bw==}
+  '@paperclipai/adapter-cursor-cloud@2026.609.0':
+    resolution: {integrity: sha512-8pf73cM0RpxKNXmnmPfiwh4czmD+EEJIT72ObwpxqdRF+2VLL0ir/agRa0omLHicc3vEYHst/3pZ1705ByH2aw==}
 
-  '@paperclipai/adapter-cursor-local@2026.529.0':
-    resolution: {integrity: sha512-yzJYzM/gdKc/XVNgboOUVtpPRIkLyekgQRXPMfEv/6hA4BAAuaHPUbuHdPRNt3sV2eOyyfT4b0igG0+3f9uDXA==}
+  '@paperclipai/adapter-cursor-local@2026.609.0':
+    resolution: {integrity: sha512-B5HoxbyjiwiQR5G74KdEWRlH5ZGOgT6HPBqkUpXJQsZSb+vHsLvl2B8DIodhVYSI+x8AOiPwTrXteQCACG/JHQ==}
 
-  '@paperclipai/adapter-gemini-local@2026.529.0':
-    resolution: {integrity: sha512-dDskbRD77JjwcR4h7htJmpYOaNDh7sL/fAWuYeAG9fLE0fg8ntS/+Z/WqDQB7nnSicWXtNmufx4CjlRacA15Iw==}
+  '@paperclipai/adapter-gemini-local@2026.609.0':
+    resolution: {integrity: sha512-dbMUZeMRtQmtaAaJ+D3hYtQ/axpFKNE4gS3ni7QHbSuUwqwXK8DOkOKV/vMvgcXcSs+GEKAYPUZ0r60pkeHCrw==}
 
-  '@paperclipai/adapter-grok-local@2026.529.0':
-    resolution: {integrity: sha512-aZu+bjt/U70eqNvtcXcCAf5nT/EveWsAp56CG2ytTVm5knPB+FBvkoJoqLAIs/yTUuSNCmO+RkWTgGlhmNdJ+Q==}
+  '@paperclipai/adapter-grok-local@2026.609.0':
+    resolution: {integrity: sha512-rrJHK5/8j/5Hm+2ZRU+j6b7csGxad97bSc8XbwprWDVYnTrpamZzSImbv1gsfOAR8LaPxKN1V/MC5e+OWURaRg==}
 
-  '@paperclipai/adapter-openclaw-gateway@2026.529.0':
-    resolution: {integrity: sha512-yM4YH1onuMD2iNktbjkBOkclLi1ULunBREhOgcsZb3kVl3uVKYpDmTs7sRczDtDHSn8Yd34BFgoG/efuHsyb9Q==}
+  '@paperclipai/adapter-openclaw-gateway@2026.609.0':
+    resolution: {integrity: sha512-drDMfiGyIZ9e7yRyv3SlnfrA4kS9o5IjjiwSVCkC1oYQMglswwP1+Sie3LADryqattrjo83cbBED2C+rY02bEA==}
 
-  '@paperclipai/adapter-opencode-local@2026.529.0':
-    resolution: {integrity: sha512-CxpIKOhQRx5i5jQt1PjG0MmwA59tw57x7NSHTov5Gk8bbVkJVo4gVbkq2y1Y4CpNJMLnSJKnURnzEomHev3Kiw==}
+  '@paperclipai/adapter-opencode-local@2026.609.0':
+    resolution: {integrity: sha512-yFS2J5UBenii3JAuVeLlvXqoOY7dAkMeRPyT/qM3HkVFUjRyyakcVjus8vOjH7rA1Hg+lQFCGpireX53nTvHlg==}
 
-  '@paperclipai/adapter-pi-local@2026.529.0':
-    resolution: {integrity: sha512-6F+T9NS+t0Ga1y82KwrRZXxcmzvnfowmbNv/jFqtroDRUji5OfQvhNXQ7knKhSfJDOwhEp7kMMHK0CTj6nxDgQ==}
+  '@paperclipai/adapter-pi-local@2026.609.0':
+    resolution: {integrity: sha512-L0dDyauMZKwZBGMalQ9Y+BEm66GgM2BRSr9EzU30g7fqPY9liCw5Mvcb7XZ148Tc2EYUhm9pcKcNjcV0/Pw7Bg==}
 
-  '@paperclipai/adapter-utils@2026.529.0':
-    resolution: {integrity: sha512-Y8sbhZTHyb9nYYAURkGZ7oxFiU5ypew1fDuFB59qjRLt7FyIJXP6HbdEVRNylSV3jlXksCxokw2LqpwIID7asQ==}
+  '@paperclipai/adapter-utils@2026.609.0':
+    resolution: {integrity: sha512-3DSmHNz5T1pXDCHVQQFg7ZS/EMwp8fHqOYrby3gT2vr2S1eovxjKS3bKs+v+NVCbDW1eQFdMqfRqFt1XkrJa4g==}
 
-  '@paperclipai/db@2026.529.0':
-    resolution: {integrity: sha512-u+JBfHb5txrlvacfVa8uJms7qNu92N/OdB+AlOPAY4S7IwBHGL7T4ct9xTp8gqhfPzp4iyauvkUztjkLsundRw==}
+  '@paperclipai/db@2026.609.0':
+    resolution: {integrity: sha512-gWenWEWFruFSwtEdVzOzV9lEylZO87xA6zXIkuTqganftk5Dy63lLsjhEh49MS0l9ywt4xv2a0QVTKoh0aj35g==}
 
-  '@paperclipai/plugin-sdk@2026.529.0':
-    resolution: {integrity: sha512-mYSs+gcIGPiF5RqtOjoMJp1NP0pxqS27ceRnkFeVhGgNFC/M5UIs+rpYdeUozGEZWfybwUlxnXbEX+yTWAMCLg==}
+  '@paperclipai/plugin-sdk@2026.609.0':
+    resolution: {integrity: sha512-/Bn9lN4JWPKevhuwK0w54IHMqOKc+4z6ZEAwoE7HR+u2V1lPbSdlNZat3LCP+m0BTOweLO7s/dwhEay8nw+rNQ==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -920,11 +925,11 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/server@2026.529.0':
-    resolution: {integrity: sha512-+mM7FszTGYJRaWpTh+OGAyjSXf5RVm1iq9jL+Q1CjOgQyzgH4WZ126LOMO5V/9uus4Tx/TggNgoNloBWvlJ/+A==}
+  '@paperclipai/server@2026.609.0':
+    resolution: {integrity: sha512-QoZK2D84kYmGInugEKaKiQ4/aRe8A3Dh5iF3e0uffBwdfUmbV9912fNauCje0EvYU8VU2Rnql4W8yHNkP/1eew==}
 
-  '@paperclipai/shared@2026.529.0':
-    resolution: {integrity: sha512-KDHhBn88murStIQ6XZCnRj5exRQla3ycj5IihEIXd8cH0bNWqacD9a/Ofq5ONriaO1mzcMp3evrbDl/jLx5Zdg==}
+  '@paperclipai/shared@2026.609.0':
+    resolution: {integrity: sha512-+jiu1EGcqMNIleX7w62B8K0yc0VxumCIyGCfCbtIVup9F3AbB1eQ8AIi/hySffFF+0SvgmkzcZsJCYvV1REzDw==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -1301,8 +1306,8 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2798,8 +2803,8 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  postgres@3.4.8:
-    resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
     engines: {node: '>=12'}
 
   postject@1.0.0-alpha.6:
@@ -4027,22 +4032,22 @@ snapshots:
 
   '@csstools/css-tokenizer@4.0.0': {}
 
-  '@cursor/sdk-darwin-arm64@1.0.12':
+  '@cursor/sdk-darwin-arm64@1.0.18':
     optional: true
 
-  '@cursor/sdk-darwin-x64@1.0.12':
+  '@cursor/sdk-darwin-x64@1.0.18':
     optional: true
 
-  '@cursor/sdk-linux-arm64@1.0.12':
+  '@cursor/sdk-linux-arm64@1.0.18':
     optional: true
 
-  '@cursor/sdk-linux-x64@1.0.12':
+  '@cursor/sdk-linux-x64@1.0.18':
     optional: true
 
-  '@cursor/sdk-win32-x64@1.0.12':
+  '@cursor/sdk-win32-x64@1.0.18':
     optional: true
 
-  '@cursor/sdk@1.0.12':
+  '@cursor/sdk@1.0.18':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
       '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
@@ -4051,11 +4056,11 @@ snapshots:
       sqlite3: 5.1.7
       zod: 3.25.76
     optionalDependencies:
-      '@cursor/sdk-darwin-arm64': 1.0.12
-      '@cursor/sdk-darwin-x64': 1.0.12
-      '@cursor/sdk-linux-arm64': 1.0.12
-      '@cursor/sdk-linux-x64': 1.0.12
-      '@cursor/sdk-win32-x64': 1.0.12
+      '@cursor/sdk-darwin-arm64': 1.0.18
+      '@cursor/sdk-darwin-x64': 1.0.18
+      '@cursor/sdk-linux-arm64': 1.0.18
+      '@cursor/sdk-linux-x64': 1.0.18
+      '@cursor/sdk-win32-x64': 1.0.18
     transitivePeerDependencies:
       - bluebird
       - supports-color
@@ -4394,8 +4399,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.18)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -4431,10 +4436,10 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
-  '@paperclipai/adapter-acpx-local@2026.529.0':
+  '@paperclipai/adapter-acpx-local@2026.609.0':
     dependencies:
       '@agentclientprotocol/claude-agent-acp': 0.31.4
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       '@zed-industries/codex-acp': 0.12.0
       acpx: 0.6.1
       picocolors: 1.1.1
@@ -4445,67 +4450,67 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@paperclipai/adapter-claude-local@2026.529.0':
+  '@paperclipai/adapter-claude-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-codex-local@2026.529.0':
+  '@paperclipai/adapter-codex-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-cursor-cloud@2026.529.0':
+  '@paperclipai/adapter-cursor-cloud@2026.609.0':
     dependencies:
-      '@cursor/sdk': 1.0.12
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@cursor/sdk': 1.0.18
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  '@paperclipai/adapter-cursor-local@2026.529.0':
+  '@paperclipai/adapter-cursor-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-gemini-local@2026.529.0':
+  '@paperclipai/adapter-gemini-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-grok-local@2026.529.0':
+  '@paperclipai/adapter-grok-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-openclaw-gateway@2026.529.0':
+  '@paperclipai/adapter-openclaw-gateway@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@paperclipai/adapter-opencode-local@2026.529.0':
+  '@paperclipai/adapter-opencode-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-pi-local@2026.529.0':
+  '@paperclipai/adapter-pi-local@2026.609.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-utils@2026.529.0': {}
+  '@paperclipai/adapter-utils@2026.609.0': {}
 
-  '@paperclipai/db@2026.529.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)':
+  '@paperclipai/db@2026.609.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)':
     dependencies:
-      '@paperclipai/shared': 2026.529.0
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      '@paperclipai/shared': 2026.609.0
+      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
-      postgres: 3.4.8
+      postgres: 3.4.9
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
       - '@cloudflare/workers-types'
@@ -4537,36 +4542,36 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@paperclipai/plugin-sdk@2026.529.0':
+  '@paperclipai/plugin-sdk@2026.609.0':
     dependencies:
-      '@paperclipai/shared': 2026.529.0
+      '@paperclipai/shared': 2026.609.0
       zod: 3.25.76
 
-  '@paperclipai/server@2026.529.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)':
+  '@paperclipai/server@2026.609.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)':
     dependencies:
       '@aws-sdk/client-s3': 3.1017.0
-      '@paperclipai/adapter-acpx-local': 2026.529.0
-      '@paperclipai/adapter-claude-local': 2026.529.0
-      '@paperclipai/adapter-codex-local': 2026.529.0
-      '@paperclipai/adapter-cursor-cloud': 2026.529.0
-      '@paperclipai/adapter-cursor-local': 2026.529.0
-      '@paperclipai/adapter-gemini-local': 2026.529.0
-      '@paperclipai/adapter-grok-local': 2026.529.0
-      '@paperclipai/adapter-openclaw-gateway': 2026.529.0
-      '@paperclipai/adapter-opencode-local': 2026.529.0
-      '@paperclipai/adapter-pi-local': 2026.529.0
-      '@paperclipai/adapter-utils': 2026.529.0
-      '@paperclipai/db': 2026.529.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)
-      '@paperclipai/plugin-sdk': 2026.529.0
-      '@paperclipai/shared': 2026.529.0
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      better-auth: 1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0)
+      '@paperclipai/adapter-acpx-local': 2026.609.0
+      '@paperclipai/adapter-claude-local': 2026.609.0
+      '@paperclipai/adapter-codex-local': 2026.609.0
+      '@paperclipai/adapter-cursor-cloud': 2026.609.0
+      '@paperclipai/adapter-cursor-local': 2026.609.0
+      '@paperclipai/adapter-gemini-local': 2026.609.0
+      '@paperclipai/adapter-grok-local': 2026.609.0
+      '@paperclipai/adapter-openclaw-gateway': 2026.609.0
+      '@paperclipai/adapter-opencode-local': 2026.609.0
+      '@paperclipai/adapter-pi-local': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/db': 2026.609.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)
+      '@paperclipai/plugin-sdk': 2026.609.0
+      '@paperclipai/shared': 2026.609.0
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      better-auth: 1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0)
       chokidar: 4.0.3
       detect-port: 2.1.0
       dompurify: 3.4.2
       dotenv: 17.3.1
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
       express: 5.2.1
       hermes-paperclip-adapter: 0.2.1
@@ -4635,7 +4640,7 @@ snapshots:
       - vitest
       - vue
 
-  '@paperclipai/shared@2026.529.0':
+  '@paperclipai/shared@2026.609.0':
     dependencies:
       zod: 3.25.76
 
@@ -5122,9 +5127,9 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
@@ -5137,7 +5142,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.18.0:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -5264,7 +5269,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7))(pg@8.20.0):
+  better-auth@1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0):
     dependencies:
       '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
       '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
@@ -5279,7 +5284,7 @@ snapshots:
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       pg: 8.20.0
 
   better-call@1.1.8(zod@4.3.6):
@@ -5654,11 +5659,11 @@ snapshots:
 
   dotenv@17.3.1: {}
 
-  drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.8)(sqlite3@5.1.7):
+  drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7):
     optionalDependencies:
       kysely: 0.28.14
       pg: 8.20.0
-      postgres: 3.4.8
+      postgres: 3.4.9
       sqlite3: 5.1.7
 
   dunder-proto@1.0.1:
@@ -6127,7 +6132,7 @@ snapshots:
 
   hermes-paperclip-adapter@0.2.1:
     dependencies:
-      '@paperclipai/adapter-utils': 2026.529.0
+      '@paperclipai/adapter-utils': 2026.609.0
       picocolors: 1.1.1
 
   hono@4.12.18: {}
@@ -6726,7 +6731,7 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  postgres@3.4.8: {}
+  postgres@3.4.9: {}
 
   postject@1.0.0-alpha.6:
     dependencies:

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -210,6 +210,28 @@ for (const arch of targetArches) {
   cpSync(path.join(stagingDir, "node_modules"), path.join(bundleServerDir, "node_modules"), { recursive: true });
   rmSync(path.join(bundleServerDir, "node_modules", ".bin"), { recursive: true, force: true });
 
+  // The @paperclipai/server package currently ships with embedded-postgres 18.x
+  // (beta), but existing data directories created by Docker or older Desktop
+  // installations use PostgreSQL 17. Downgrade to the latest PG17 release so
+  // that Desktop can open those data directories without a manual pg_upgrade.
+  //
+  // Once @paperclipai/server ships with PG17 by default this block can be removed.
+  console.log(`[prepare-server] Pinning embedded-postgres to PG17 for ${variant}...`);
+  execSync(
+    `npm install embedded-postgres@17.10.0-beta.17 --save-exact --no-audit --os=${nodePlatform} --cpu=${arch} --arch=${arch}`,
+    {
+      cwd: bundleServerDir,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        npm_config_arch: arch,
+        npm_config_platform: nodePlatform,
+        npm_config_target_arch: arch,
+      },
+    },
+  );
+  console.log(`[prepare-server] embedded-postgres pinned to PG17 for ${variant}.`);
+
   if (platform === "darwin") {
     console.log(`[prepare-server] Fixing dylib symlinks for ${variant} embedded-postgres...`);
     const embeddedPgScope = path.join(bundleServerDir, "node_modules", "@embedded-postgres");

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -28,46 +28,14 @@ const projectRoot = path.resolve(__dirname, "..");
 const stagingRootDir = path.join(projectRoot, "build", "server-staging");
 const bundleRootDir = path.join(projectRoot, "build", "server-bundle");
 
-function firstExistingPath(paths) {
-  for (const candidate of paths) {
-    if (existsSync(candidate)) return candidate;
-  }
-  return null;
-}
-
-function resolveLocalSkillsCatalogSource() {
-  const envRoot = process.env.PAPERCLIP_MONOREPO_ROOT?.trim();
-  const repoCandidates = [
-    ...(envRoot ? [path.resolve(envRoot)] : []),
-    path.resolve(projectRoot, "..", "paperclip-fork"),
-    path.resolve(projectRoot, "..", "paperclip-upstream"),
-    path.resolve(projectRoot, "..", "paperclip-development"),
-  ];
-  for (const repoRoot of repoCandidates) {
-    const packageDir = path.join(repoRoot, "packages", "skills-catalog");
-    const generatedCatalog = path.join(packageDir, "generated", "catalog.json");
-    if (existsSync(generatedCatalog)) {
-      return { repoRoot, packageDir, generatedCatalog };
-    }
-  }
-  return null;
-}
-
-const localSkillsCatalogSource = resolveLocalSkillsCatalogSource();
-if (localSkillsCatalogSource) {
-  console.log(`[prepare-server] Using local skills catalog source: ${localSkillsCatalogSource.packageDir}`);
-}
-
 const projectPkg = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8"));
 const serverVersion = projectPkg.devDependencies["@paperclipai/server"];
-const skillsCatalogVersion = serverVersion;
 if (!serverVersion) {
   console.error("[prepare-server] @paperclipai/server not found in devDependencies");
   process.exit(1);
 }
 
 console.log(`[prepare-server] Target server version: @paperclipai/server@${serverVersion}`);
-console.log(`[prepare-server] Target skills catalog version: @paperclipai/skills-catalog@${skillsCatalogVersion}`);
 
 const platform = process.platform;
 const nodePlatform = platform === "win32" ? "win32" : platform;
@@ -205,8 +173,6 @@ for (const arch of targetArches) {
   const stagingDir = path.join(stagingRootDir, variant);
   const bundleDir = path.join(bundleRootDir, variant);
   const bundleServerDir = path.join(bundleDir, "server");
-  const bundlePackagesDir = path.join(bundleDir, "packages");
-  const bundleSkillsCatalogDir = path.join(bundlePackagesDir, "skills-catalog");
 
   console.log(`[prepare-server] Installing runtime bundle for ${variant}...`);
 
@@ -216,10 +182,7 @@ for (const arch of targetArches) {
     JSON.stringify(
       {
         private: true,
-        dependencies: {
-          "@paperclipai/server": serverVersion,
-          ...(localSkillsCatalogSource ? {} : { "@paperclipai/skills-catalog": skillsCatalogVersion }),
-        },
+        dependencies: { "@paperclipai/server": serverVersion },
         overrides: {
           // cssstyle currently resolves a 5.x css-color release that trips
           // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
@@ -249,7 +212,6 @@ for (const arch of targetArches) {
   mkdirSync(bundleServerDir, { recursive: true });
 
   const serverPkgDir = path.join(stagingDir, "node_modules", "@paperclipai", "server");
-  const skillsCatalogPkgDir = path.join(stagingDir, "node_modules", "@paperclipai", "skills-catalog");
 
   cpSync(path.join(serverPkgDir, "dist"), path.join(bundleServerDir, "dist"), { recursive: true });
   cpSync(path.join(serverPkgDir, "package.json"), path.join(bundleServerDir, "package.json"));
@@ -261,22 +223,6 @@ for (const arch of targetArches) {
 
   cpSync(path.join(stagingDir, "node_modules"), path.join(bundleServerDir, "node_modules"), { recursive: true });
   rmSync(path.join(bundleServerDir, "node_modules", ".bin"), { recursive: true, force: true });
-
-  mkdirSync(bundlePackagesDir, { recursive: true });
-  const resolvedSkillsCatalogSource = localSkillsCatalogSource?.packageDir ?? (existsSync(skillsCatalogPkgDir) ? skillsCatalogPkgDir : null);
-  if (resolvedSkillsCatalogSource) {
-    cpSync(resolvedSkillsCatalogSource, bundleSkillsCatalogDir, { recursive: true });
-  } else {
-    console.error(`[prepare-server] ERROR: @paperclipai/skills-catalog not found locally or at ${skillsCatalogPkgDir}`);
-    process.exit(1);
-  }
-
-  const generatedCatalogPath = path.join(bundleSkillsCatalogDir, "generated", "catalog.json");
-  if (!existsSync(generatedCatalogPath)) {
-    console.error(`[prepare-server] ERROR: skills catalog manifest missing at ${generatedCatalogPath}`);
-    process.exit(1);
-  }
-  console.log(`[prepare-server] Skills catalog manifest bundled: ${generatedCatalogPath}`);
 
   // The @paperclipai/server package currently ships with embedded-postgres 18.x
   // (beta), but existing data directories created by Docker or older Desktop

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -14,6 +14,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -149,6 +150,19 @@ function normalizeEsbuildBinary(bundleServerDir, arch) {
   );
 
   if (!existsSync(esbuildBin) || !existsSync(archEsbuildBin)) return;
+
+  // Skip if source and destination are already the same file (same inode = hardlink,
+  // or same resolved symlink path) — avoids EINVAL from cpSync.
+  try {
+    const srcStat = lstatSync(archEsbuildBin);
+    const dstStat = lstatSync(esbuildBin);
+    if (srcStat.ino === dstStat.ino && srcStat.dev === dstStat.dev) {
+      console.log(`[prepare-server] esbuild binary already correct for darwin-${packageArch}, skipping.`);
+      return;
+    }
+  } catch {
+    // stat failed — fall through and let cpSync handle it
+  }
 
   cpSync(archEsbuildBin, esbuildBin);
   console.log(`[prepare-server] Normalized esbuild binary for darwin-${packageArch}.`);

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -28,14 +28,46 @@ const projectRoot = path.resolve(__dirname, "..");
 const stagingRootDir = path.join(projectRoot, "build", "server-staging");
 const bundleRootDir = path.join(projectRoot, "build", "server-bundle");
 
+function firstExistingPath(paths) {
+  for (const candidate of paths) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+function resolveLocalSkillsCatalogSource() {
+  const envRoot = process.env.PAPERCLIP_MONOREPO_ROOT?.trim();
+  const repoCandidates = [
+    ...(envRoot ? [path.resolve(envRoot)] : []),
+    path.resolve(projectRoot, "..", "paperclip-fork"),
+    path.resolve(projectRoot, "..", "paperclip-upstream"),
+    path.resolve(projectRoot, "..", "paperclip-development"),
+  ];
+  for (const repoRoot of repoCandidates) {
+    const packageDir = path.join(repoRoot, "packages", "skills-catalog");
+    const generatedCatalog = path.join(packageDir, "generated", "catalog.json");
+    if (existsSync(generatedCatalog)) {
+      return { repoRoot, packageDir, generatedCatalog };
+    }
+  }
+  return null;
+}
+
+const localSkillsCatalogSource = resolveLocalSkillsCatalogSource();
+if (localSkillsCatalogSource) {
+  console.log(`[prepare-server] Using local skills catalog source: ${localSkillsCatalogSource.packageDir}`);
+}
+
 const projectPkg = JSON.parse(readFileSync(path.join(projectRoot, "package.json"), "utf8"));
 const serverVersion = projectPkg.devDependencies["@paperclipai/server"];
+const skillsCatalogVersion = serverVersion;
 if (!serverVersion) {
   console.error("[prepare-server] @paperclipai/server not found in devDependencies");
   process.exit(1);
 }
 
 console.log(`[prepare-server] Target server version: @paperclipai/server@${serverVersion}`);
+console.log(`[prepare-server] Target skills catalog version: @paperclipai/skills-catalog@${skillsCatalogVersion}`);
 
 const platform = process.platform;
 const nodePlatform = platform === "win32" ? "win32" : platform;
@@ -173,6 +205,8 @@ for (const arch of targetArches) {
   const stagingDir = path.join(stagingRootDir, variant);
   const bundleDir = path.join(bundleRootDir, variant);
   const bundleServerDir = path.join(bundleDir, "server");
+  const bundlePackagesDir = path.join(bundleDir, "packages");
+  const bundleSkillsCatalogDir = path.join(bundlePackagesDir, "skills-catalog");
 
   console.log(`[prepare-server] Installing runtime bundle for ${variant}...`);
 
@@ -182,7 +216,10 @@ for (const arch of targetArches) {
     JSON.stringify(
       {
         private: true,
-        dependencies: { "@paperclipai/server": serverVersion },
+        dependencies: {
+          "@paperclipai/server": serverVersion,
+          ...(localSkillsCatalogSource ? {} : { "@paperclipai/skills-catalog": skillsCatalogVersion }),
+        },
         overrides: {
           // cssstyle currently resolves a 5.x css-color release that trips
           // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
@@ -212,6 +249,7 @@ for (const arch of targetArches) {
   mkdirSync(bundleServerDir, { recursive: true });
 
   const serverPkgDir = path.join(stagingDir, "node_modules", "@paperclipai", "server");
+  const skillsCatalogPkgDir = path.join(stagingDir, "node_modules", "@paperclipai", "skills-catalog");
 
   cpSync(path.join(serverPkgDir, "dist"), path.join(bundleServerDir, "dist"), { recursive: true });
   cpSync(path.join(serverPkgDir, "package.json"), path.join(bundleServerDir, "package.json"));
@@ -223,6 +261,22 @@ for (const arch of targetArches) {
 
   cpSync(path.join(stagingDir, "node_modules"), path.join(bundleServerDir, "node_modules"), { recursive: true });
   rmSync(path.join(bundleServerDir, "node_modules", ".bin"), { recursive: true, force: true });
+
+  mkdirSync(bundlePackagesDir, { recursive: true });
+  const resolvedSkillsCatalogSource = localSkillsCatalogSource?.packageDir ?? (existsSync(skillsCatalogPkgDir) ? skillsCatalogPkgDir : null);
+  if (resolvedSkillsCatalogSource) {
+    cpSync(resolvedSkillsCatalogSource, bundleSkillsCatalogDir, { recursive: true });
+  } else {
+    console.error(`[prepare-server] ERROR: @paperclipai/skills-catalog not found locally or at ${skillsCatalogPkgDir}`);
+    process.exit(1);
+  }
+
+  const generatedCatalogPath = path.join(bundleSkillsCatalogDir, "generated", "catalog.json");
+  if (!existsSync(generatedCatalogPath)) {
+    console.error(`[prepare-server] ERROR: skills catalog manifest missing at ${generatedCatalogPath}`);
+    process.exit(1);
+  }
+  console.log(`[prepare-server] Skills catalog manifest bundled: ${generatedCatalogPath}`);
 
   // The @paperclipai/server package currently ships with embedded-postgres 18.x
   // (beta), but existing data directories created by Docker or older Desktop


### PR DESCRIPTION
## Problem

Paperclip Desktop currently ships with `embedded-postgres 18.x` (beta). The official Paperclip Docker deployment initializes PostgreSQL 17. Anyone migrating from Docker to Desktop hits two errors in sequence:

**Error 1** — `postgresql.conf` locale mismatch (fixed upstream in [paperclipai/paperclip#7894](https://github.com/paperclipai/paperclip/pull/7894)):
```
LOG:  invalid value for parameter "lc_messages": "en_US.utf8"
FATAL: configuration file contains errors
```

**Error 2** — DB catalog `LC_COLLATE` incompatibility:
```
PostgresError: database locale is incompatible with operating system
detail: The database was initialized with LC_COLLATE "en_US.utf8",
        which is not recognized by setlocale().
```

Linux uses `en_US.utf8`, macOS uses `en_US.UTF-8`. PostgreSQL stores the locale at `initdb` time — a cluster initialized on Linux cannot be opened on macOS without migration.

## Changes

### `scripts/prepare-server.mjs`

After assembling the server bundle, downgrade `embedded-postgres` from 18.x to `17.10.0-beta.17` so Desktop can open existing PG17 data directories (Docker or older Desktop installs) without a manual `pg_upgrade`.

This is intentionally a targeted downgrade with a clear comment marking it as temporary — once `@paperclipai/server` ships with PG17 as the default, the block can be removed.

### `docs/guides/docker-to-desktop-migration.md`

Step-by-step migration guide covering:
- One-time `pg_dump` / `pg_restore` to migrate LC_COLLATE metadata
- `PAPERCLIP_HOME` and `config.json` configuration for Desktop
- Rollback instructions (old Docker data is preserved)
- Alternative: keeping Docker Postgres as the backend for Desktop

## Testing

Verified end-to-end on macOS arm64:
- Docker data directory (PG17, `en_US.utf8`) successfully opened by Paperclip Desktop after following the migration guide
- All agents, companies, issues and runs intact after restore
- Desktop runs without Docker after migration

## Related

- paperclipai/paperclip#7894 — upstream fix for `postgresql.conf` locale normalization