### PR TITLE
Harden desktop crash recovery and release packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,21 +36,38 @@
     "tree-kill": "^1.2.2"
   },
   "devDependencies": {
-    "@paperclipai/server": "2026.609.0",
+    "@paperclipai/server": "2026.618.0",
     "electron": "^41.7.2",
     "electron-builder": "^26.8.1",
     "typescript": "^5.7.3"
   },
   "pnpm": {
     "overrides": {
+      "@anthropic-ai/sdk": "0.91.1",
+      "@tootallnate/once": "2.0.1",
       "@xmldom/xmldom": "0.8.13",
+      "better-auth": "1.6.11",
       "brace-expansion@1.1.12": "1.1.13",
       "brace-expansion@2.0.2": "2.0.3",
+      "brace-expansion@5.0.5": "5.0.6",
       "defu": "6.1.7",
-      "dompurify": "3.4.2",
+      "dompurify": "3.4.11",
+      "esbuild": "0.28.1",
+      "fast-uri": "3.1.2",
       "fast-xml-parser": "5.7.3",
+      "form-data": "4.0.6",
+      "hono": "4.12.25",
+      "js-yaml": "4.2.0",
+      "kysely": "0.28.17",
       "lodash": "4.18.1",
-      "path-to-regexp": "8.4.2"
+      "multer": "2.2.0",
+      "path-to-regexp": "8.4.2",
+      "qs": "6.15.2",
+      "tar": "7.5.16",
+      "tmp": "0.2.7",
+      "undici@5.29.0": "6.24.0",
+      "undici@7.24.6": "7.28.0",
+      "ws": "8.21.0"
     },
     "onlyBuiltDependencies": [
       "@embedded-postgres/darwin-arm64",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "paperclip-desktop",
   "version": "3.2.9",
   "private": true,
-  "description": "Paperclip desktop application — Electron wrapper for the Paperclip server",
+  "description": "Paperclip desktop application \u2014 Electron wrapper for the Paperclip server",
   "author": {
     "name": "Aron Prins"
   },
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@paperclipai/server": "2026.609.0",
-    "electron": "^41.5.0",
+    "electron": "^41.7.2",
     "electron-builder": "^26.8.1",
     "typescript": "^5.7.3"
   },
@@ -51,6 +51,13 @@
       "fast-xml-parser": "5.7.3",
       "lodash": "4.18.1",
       "path-to-regexp": "8.4.2"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@embedded-postgres/darwin-arm64",
+      "@embedded-postgres/darwin-x64",
+      "electron",
+      "electron-winstaller",
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,8 +32,8 @@ importers:
         specifier: 2026.609.0
         version: 2026.609.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       electron:
-        specifier: ^41.5.0
-        version: 41.5.0
+        specifier: ^41.7.2
+        version: 41.7.2
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)
@@ -417,6 +417,10 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
+  '@electron-internal/extract-zip@1.0.3':
+    resolution: {integrity: sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==}
+    engines: {node: '>=22.12.0'}
+
   '@electron/asar@3.4.1':
     resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
     engines: {node: '>=10.12.0'}
@@ -426,13 +430,13 @@ packages:
     resolution: {integrity: sha512-zx0EIq78WlY/lBb1uXlziZmDZI4ubcCXIMJ4uGjXzZW0nS19TjSPeXPAjzzTmKQlJUZm0SbmZhPKP7tuQ1SsEw==}
     hasBin: true
 
-  '@electron/get@2.0.3':
-    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
-    engines: {node: '>=12'}
-
   '@electron/get@3.1.0':
     resolution: {integrity: sha512-F+nKc0xW+kVbBRhFzaMgPy3KwmuNTYX1fx6+FxxoSnNgwYX6LD7AKBTWkU0MQ6IBoe7dz069CNkR673sPAgkCQ==}
     engines: {node: '>=14'}
+
+  '@electron/get@5.0.0':
+    resolution: {integrity: sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==}
+    engines: {node: '>=22.12.0'}
 
   '@electron/notarize@2.5.0':
     resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
@@ -1207,9 +1211,6 @@ packages:
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
     engines: {node: '>=10.0.0'}
@@ -1525,9 +1526,6 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1934,9 +1932,9 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.5.0:
-    resolution: {integrity: sha512-x9j9//PubUA4EjDtQbZhtk3prolandqCKgit0uCIqc1jb8FTskPbnJtxcDFB1aejczJcuERgjPixBUaMwoWyJg==}
-    engines: {node: '>= 12.20.55'}
+  electron@41.7.2:
+    resolution: {integrity: sha512-oYbZNimoMlAy6Fp/o5x2vTggptuPsIbnPKCb6jGf1PJStXH7Gkw0MUQrBliHmDqKLW7yeE+SPsvFNILVN0ORMQ==}
+    engines: {node: '>= 22.12.0'}
     hasBin: true
 
   embedded-postgres@18.1.0-beta.16:
@@ -1963,6 +1961,10 @@ packages:
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
@@ -2034,11 +2036,6 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   extsprintf@1.4.1:
     resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
     engines: {'0': node >=0.6.0}
@@ -2076,9 +2073,6 @@ packages:
   fast-xml-parser@5.7.3:
     resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2714,9 +2708,6 @@ packages:
   pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
     engines: {node: '>=12', npm: '>=6'}
-
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -3406,9 +3397,6 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -4070,6 +4058,8 @@ snapshots:
       ajv: 6.14.0
       ajv-keywords: 3.5.2(ajv@6.14.0)
 
+  '@electron-internal/extract-zip@1.0.3': {}
+
   '@electron/asar@3.4.1':
     dependencies:
       commander: 5.1.0
@@ -4082,7 +4072,7 @@ snapshots:
       fs-extra: 9.1.0
       minimist: 1.2.8
 
-  '@electron/get@2.0.3':
+  '@electron/get@3.1.0':
     dependencies:
       debug: 4.4.3
       env-paths: 2.2.1
@@ -4096,17 +4086,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/get@3.1.0':
+  '@electron/get@5.0.0':
     dependencies:
       debug: 4.4.3
-      env-paths: 2.2.1
-      fs-extra: 8.1.0
-      got: 11.8.6
+      env-paths: 3.0.0
+      graceful-fs: 4.2.11
       progress: 2.0.3
-      semver: 6.3.1
+      semver: 7.7.4
       sumchecker: 3.0.1
     optionalDependencies:
-      global-agent: 3.0.0
+      undici: 7.24.6
     transitivePeerDependencies:
       - supports-color
 
@@ -5049,11 +5038,6 @@ snapshots:
   '@types/verror@1.10.11':
     optional: true
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 25.5.0
-    optional: true
-
   '@xmldom/xmldom@0.8.13': {}
 
   '@zed-industries/codex-acp-darwin-arm64@0.12.0':
@@ -5341,8 +5325,6 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
-
-  buffer-crc32@0.2.13: {}
 
   buffer-from@1.1.2: {}
 
@@ -5743,11 +5725,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.5.0:
+  electron@41.7.2:
     dependencies:
-      '@electron/get': 2.0.3
+      '@electron-internal/extract-zip': 1.0.3
+      '@electron/get': 5.0.0
       '@types/node': 24.12.0
-      extract-zip: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -5783,6 +5765,8 @@ snapshots:
   entities@6.0.1: {}
 
   env-paths@2.2.1: {}
+
+  env-paths@3.0.0: {}
 
   err-code@2.0.3: {}
 
@@ -5896,16 +5880,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   extsprintf@1.4.1:
     optional: true
 
@@ -5941,10 +5915,6 @@ snapshots:
       fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6624,8 +6594,6 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pe-library@0.4.1: {}
-
-  pend@1.2.0: {}
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -7399,11 +7367,6 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,14 +5,31 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@anthropic-ai/sdk': 0.91.1
+  '@tootallnate/once': 2.0.1
   '@xmldom/xmldom': 0.8.13
+  better-auth: 1.6.11
   brace-expansion@1.1.12: 1.1.13
   brace-expansion@2.0.2: 2.0.3
+  brace-expansion@5.0.5: 5.0.6
   defu: 6.1.7
-  dompurify: 3.4.2
+  dompurify: 3.4.11
+  esbuild: 0.28.1
+  fast-uri: 3.1.2
   fast-xml-parser: 5.7.3
+  form-data: 4.0.6
+  hono: 4.12.25
+  js-yaml: 4.2.0
+  kysely: 0.28.17
   lodash: 4.18.1
+  multer: 2.2.0
   path-to-regexp: 8.4.2
+  qs: 6.15.2
+  tar: 7.5.16
+  tmp: 0.2.7
+  undici@5.29.0: 6.24.0
+  undici@7.24.6: 7.28.0
+  ws: 8.21.0
 
 importers:
 
@@ -29,8 +46,8 @@ importers:
         version: 1.2.2
     devDependencies:
       '@paperclipai/server':
-        specifier: 2026.609.0
-        version: 2026.609.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
+        specifier: 2026.618.0
+        version: 2026.618.0(@noble/hashes@2.0.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       electron:
         specifier: ^41.7.2
         version: 41.7.2
@@ -113,8 +130,8 @@ packages:
     peerDependencies:
       zod: ^4.0.0
 
-  '@anthropic-ai/sdk@0.81.0':
-    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -295,23 +312,81 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/core@1.4.18':
-    resolution: {integrity: sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==}
+  '@better-auth/core@1.6.11':
+    resolution: {integrity: sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ==}
     peerDependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
-      better-call: 1.1.8
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.5
       jose: ^6.1.0
-      kysely: ^0.28.5
+      kysely: 0.28.17
       nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
 
-  '@better-auth/telemetry@1.4.18':
-    resolution: {integrity: sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ==}
+  '@better-auth/drizzle-adapter@1.6.11':
+    resolution: {integrity: sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw==}
     peerDependencies:
-      '@better-auth/core': 1.4.18
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
 
-  '@better-auth/utils@0.3.0':
-    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+  '@better-auth/kysely-adapter@1.6.11':
+    resolution: {integrity: sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+      kysely: 0.28.17
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.11':
+    resolution: {integrity: sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.11':
+    resolution: {integrity: sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.11':
+    resolution: {integrity: sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.11':
+    resolution: {integrity: sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.11
+      '@better-auth/utils': 0.4.0
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.4.0':
+    resolution: {integrity: sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA==}
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
@@ -512,158 +587,158 @@ packages:
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -677,10 +752,6 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@fastify/busboy@2.1.1':
-    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
-    engines: {node: '>=14'}
-
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
@@ -688,7 +759,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.25
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -884,44 +955,52 @@ packages:
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
 
-  '@paperclipai/adapter-acpx-local@2026.609.0':
-    resolution: {integrity: sha512-A2XyBq42Uq5hGQbzLjhuS9b3gTqb8ABiKERIh3gnmRUH6tFbsBg+rdWNyXIR7dSNmYwkBW2TOddmZpdrI6gdMA==}
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
-  '@paperclipai/adapter-claude-local@2026.609.0':
-    resolution: {integrity: sha512-VNWM/wfYTWNdyw1AdYyzkUe6DM4ZM2WfVBlpMOI2abdX1JNUfv2t/TMsZnulkLpIRWsvpsh7NoEyn5BX2vGUTQ==}
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
 
-  '@paperclipai/adapter-codex-local@2026.609.0':
-    resolution: {integrity: sha512-2uY5jAuKH3d0CvPnoNfi5wayRW1ndzS4HWg1Ewp/m8R2l6hat5wI/hu28jlchQKYrw8HQwltGGXmADqoFEM5yw==}
+  '@paperclipai/adapter-acpx-local@2026.618.0':
+    resolution: {integrity: sha512-ouES6ukQcshC7lFEiU1Lt1Kt0/dkHwSH/UNR7yiADuSU7eQM9Idcmchv5sa3322HTAWU9yBgdFCX/FORwUEWFQ==}
 
-  '@paperclipai/adapter-cursor-cloud@2026.609.0':
-    resolution: {integrity: sha512-8pf73cM0RpxKNXmnmPfiwh4czmD+EEJIT72ObwpxqdRF+2VLL0ir/agRa0omLHicc3vEYHst/3pZ1705ByH2aw==}
+  '@paperclipai/adapter-claude-local@2026.618.0':
+    resolution: {integrity: sha512-H4AsczsdSKRPVn96zPNRQiVwdS5ph8d0NORsRSkCocQukpFSdyYUHDoti9Lz/qFQzj+BqPuj7zjL1NRUFVUV1g==}
 
-  '@paperclipai/adapter-cursor-local@2026.609.0':
-    resolution: {integrity: sha512-B5HoxbyjiwiQR5G74KdEWRlH5ZGOgT6HPBqkUpXJQsZSb+vHsLvl2B8DIodhVYSI+x8AOiPwTrXteQCACG/JHQ==}
+  '@paperclipai/adapter-codex-local@2026.618.0':
+    resolution: {integrity: sha512-Twy25KNqEoJuqWNdP+uD+vGTQ0uVSnwTN764z0KcBslobCqbZ7KGzgF7o0YnXwGsc1RJWBgArRw1Cl52YGlPgQ==}
 
-  '@paperclipai/adapter-gemini-local@2026.609.0':
-    resolution: {integrity: sha512-dbMUZeMRtQmtaAaJ+D3hYtQ/axpFKNE4gS3ni7QHbSuUwqwXK8DOkOKV/vMvgcXcSs+GEKAYPUZ0r60pkeHCrw==}
+  '@paperclipai/adapter-cursor-cloud@2026.618.0':
+    resolution: {integrity: sha512-BKLpmLNosBVJHVDP9vG4o92R4xoUMGHA1ig7wBaok4zABqYHqO9vu4C8qRP7PAI7ng+IRcPW6oUtxR3tiP199A==}
 
-  '@paperclipai/adapter-grok-local@2026.609.0':
-    resolution: {integrity: sha512-rrJHK5/8j/5Hm+2ZRU+j6b7csGxad97bSc8XbwprWDVYnTrpamZzSImbv1gsfOAR8LaPxKN1V/MC5e+OWURaRg==}
+  '@paperclipai/adapter-cursor-local@2026.618.0':
+    resolution: {integrity: sha512-bpQRynioaCC4Brn0B7epHzKpKmxHL02qZoAabQ3Kpd+7oHenVzoF2zJ7mQS19FAVFsHjDFS2paOn5SoUDrnFMA==}
 
-  '@paperclipai/adapter-openclaw-gateway@2026.609.0':
-    resolution: {integrity: sha512-drDMfiGyIZ9e7yRyv3SlnfrA4kS9o5IjjiwSVCkC1oYQMglswwP1+Sie3LADryqattrjo83cbBED2C+rY02bEA==}
+  '@paperclipai/adapter-gemini-local@2026.618.0':
+    resolution: {integrity: sha512-nUEhEdVCfnrJWr2r8Sv3y841KrweRC2BSbeToEBj0X1aUM3di+M8V2GUdL5PjcMSNbJBbGpre16qq+RTJsJYcg==}
 
-  '@paperclipai/adapter-opencode-local@2026.609.0':
-    resolution: {integrity: sha512-yFS2J5UBenii3JAuVeLlvXqoOY7dAkMeRPyT/qM3HkVFUjRyyakcVjus8vOjH7rA1Hg+lQFCGpireX53nTvHlg==}
+  '@paperclipai/adapter-grok-local@2026.618.0':
+    resolution: {integrity: sha512-gbGWluD6nKEpWdTDCj0VpoXmVsinKnmp8R8mfuGsNkggzx+mn45CynipqWowlsivE6YbXNLnNCwVjYE6lKYpSA==}
 
-  '@paperclipai/adapter-pi-local@2026.609.0':
-    resolution: {integrity: sha512-L0dDyauMZKwZBGMalQ9Y+BEm66GgM2BRSr9EzU30g7fqPY9liCw5Mvcb7XZ148Tc2EYUhm9pcKcNjcV0/Pw7Bg==}
+  '@paperclipai/adapter-openclaw-gateway@2026.618.0':
+    resolution: {integrity: sha512-Ug8z4dcH2Eiz/T2fBBHmFMNqUyTjJIWPkjyPJ9UH5p86OQFTGO9E5fPdwESCOaJH6W/+2sRFc41P/N8RH0CV2Q==}
 
-  '@paperclipai/adapter-utils@2026.609.0':
-    resolution: {integrity: sha512-3DSmHNz5T1pXDCHVQQFg7ZS/EMwp8fHqOYrby3gT2vr2S1eovxjKS3bKs+v+NVCbDW1eQFdMqfRqFt1XkrJa4g==}
+  '@paperclipai/adapter-opencode-local@2026.618.0':
+    resolution: {integrity: sha512-UQ/hPPM1YbjK8ZejDiDCGyiasUQji9RE8CNH+gpsCWFWZFqeeCi2Y0dOzcWVbyoLD0k9sh8D79rMojTKMiXQSg==}
 
-  '@paperclipai/db@2026.609.0':
-    resolution: {integrity: sha512-gWenWEWFruFSwtEdVzOzV9lEylZO87xA6zXIkuTqganftk5Dy63lLsjhEh49MS0l9ywt4xv2a0QVTKoh0aj35g==}
+  '@paperclipai/adapter-pi-local@2026.618.0':
+    resolution: {integrity: sha512-5klCKxVNX5ooaZD6xCpn3OUf3wp863dq7Ffm9q7vFdUmy4rZal+5t3SimAml9Q0qLOnnRO4Y2vMsaaomIlvuTA==}
 
-  '@paperclipai/plugin-sdk@2026.609.0':
-    resolution: {integrity: sha512-/Bn9lN4JWPKevhuwK0w54IHMqOKc+4z6ZEAwoE7HR+u2V1lPbSdlNZat3LCP+m0BTOweLO7s/dwhEay8nw+rNQ==}
+  '@paperclipai/adapter-utils@2026.618.0':
+    resolution: {integrity: sha512-sZPoth909Y6T7ZwUaSFntkZzHUCoDvcb8h0f8xte21XMTuija8PzZ9+JkNVGbafQrAtyCokk2i3q1LocCb93dQ==}
+
+  '@paperclipai/db@2026.618.0':
+    resolution: {integrity: sha512-SlZtYKaot+NmQDKK0LaoIl0RdF1bvi/leBaQEuQsdh4DtxnxqMpSLGfubdOTMO7yLJjdwILNCkLBXyWDTvnZqg==}
+
+  '@paperclipai/plugin-sdk@2026.618.0':
+    resolution: {integrity: sha512-/8hoPh4x70/1HoaAe8Hofej1Ww5RLpMfbQb8fiXpRcLY9MkEN7XjzR0jVqTw4y2bwed+xQRhPJ5QRcviM/lPkA==}
     hasBin: true
     peerDependencies:
       react: '>=18'
@@ -929,11 +1008,11 @@ packages:
       react:
         optional: true
 
-  '@paperclipai/server@2026.609.0':
-    resolution: {integrity: sha512-QoZK2D84kYmGInugEKaKiQ4/aRe8A3Dh5iF3e0uffBwdfUmbV9912fNauCje0EvYU8VU2Rnql4W8yHNkP/1eew==}
+  '@paperclipai/server@2026.618.0':
+    resolution: {integrity: sha512-am+YEJj/o6nHC17F1g4EpvAgY4F353zcXlkVUWEnZTPQ12w9oIp46R4zH89HnV4nddk3VwTdo7y8gsRN18DHXQ==}
 
-  '@paperclipai/shared@2026.609.0':
-    resolution: {integrity: sha512-+jiu1EGcqMNIleX7w62B8K0yc0VxumCIyGCfCbtIVup9F3AbB1eQ8AIi/hySffFF+0SvgmkzcZsJCYvV1REzDw==}
+  '@paperclipai/shared@2026.618.0':
+    resolution: {integrity: sha512-DqfQLUiWHhYRXFtMpPCeXpB+21obNYFnqcr4bEPdRrA83l5YS/SolsqfnHu8Mj65iiSrHGhQGGc7q4kvQkV2qw==}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -1171,9 +1250,9 @@ packages:
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
 
-  '@tootallnate/once@1.1.2':
-    resolution: {integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==}
-    engines: {node: '>= 6'}
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
 
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
@@ -1427,8 +1506,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  better-auth@1.4.18:
-    resolution: {integrity: sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==}
+  better-auth@1.6.11:
+    resolution: {integrity: sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1437,7 +1516,7 @@ packages:
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
       drizzle-kit: '>=0.31.4'
-      drizzle-orm: '>=0.41.0'
+      drizzle-orm: ^0.45.2
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -1489,8 +1568,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.1.8:
-    resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+  better-call@1.3.5:
+    resolution: {integrity: sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -1523,8 +1602,8 @@ packages:
   brace-expansion@2.0.3:
     resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   buffer-from@1.1.2:
@@ -1791,8 +1870,8 @@ packages:
     os: [darwin]
     hasBin: true
 
-  dompurify@3.4.2:
-    resolution: {integrity: sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==}
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
@@ -1831,7 +1910,7 @@ packages:
       expo-sqlite: '>=14.0.0'
       gel: '>=2'
       knex: '*'
-      kysely: '*'
+      kysely: 0.28.17
       mysql2: '>=2'
       pg: '>=8'
       postgres: '>=3'
@@ -1988,8 +2067,8 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2061,8 +2140,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -2093,8 +2172,8 @@ packages:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -2215,6 +2294,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
@@ -2222,8 +2305,8 @@ packages:
     resolution: {integrity: sha512-9D4SrmMXm4AhOZ08lnlGCZBzwfRnGjzZjkvPlkRfoPTODM2YeIAaEk+zO0vInh8DI4Qr3ySN8hLFxV1eKRYFaA==}
     engines: {node: '>=20.0.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -2375,8 +2458,8 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsdom@28.1.0:
@@ -2421,8 +2504,8 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  kysely@0.28.14:
-    resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   lazy-val@1.0.5:
@@ -2548,10 +2631,6 @@ packages:
     resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
     engines: {node: '>=8'}
 
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -2579,8 +2658,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.1.1:
-    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
   nanostores@1.2.0:
@@ -2850,8 +2929,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.0:
-    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
@@ -2994,8 +3073,8 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3151,13 +3230,8 @@ packages:
   tar-stream@3.2.0:
     resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  tar@7.5.14:
-    resolution: {integrity: sha512-/7sHKgQO3JLP9ESlwTYUUftHUadOURUqq23xs1vjcnp8Vss6k0wCfzulyEtk5g91pjvnuriimGlyG7k6msrzRw==}
+  tar@7.5.16:
+    resolution: {integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==}
     engines: {node: '>=18'}
 
   teex@1.0.1:
@@ -3196,8 +3270,8 @@ packages:
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   toidentifier@1.0.1:
@@ -3259,16 +3333,16 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@5.29.0:
-    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
-    engines: {node: '>=14.0'}
+  undici@6.24.0:
+    resolution: {integrity: sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==}
+    engines: {node: '>=18.17'}
 
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.6:
-    resolution: {integrity: sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unique-filename@1.1.1:
@@ -3347,8 +3421,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3461,7 +3535,7 @@ snapshots:
 
   '@anthropic-ai/claude-agent-sdk@0.2.121(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
@@ -3477,7 +3551,7 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -3947,24 +4021,58 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
-  '@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)':
+  '@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)':
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
+      '@opentelemetry/semantic-conventions': 1.41.1
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
 
-  '@better-auth/telemetry@1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))':
+  '@better-auth/drizzle-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))':
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
+
+  '@better-auth/kysely-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+    optionalDependencies:
+      kysely: 0.28.17
+
+  '@better-auth/memory-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/mongo-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/prisma-adapter@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
+
+  '@better-auth/telemetry@1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)':
+    dependencies:
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
 
-  '@better-auth/utils@0.3.0': {}
+  '@better-auth/utils@0.4.0':
+    dependencies:
+      '@noble/hashes': 2.0.1
 
   '@better-fetch/fetch@1.1.21': {}
 
@@ -3990,7 +4098,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 1.10.0
       '@connectrpc/connect': 1.7.0(@bufbuild/protobuf@1.10.0)
-      undici: 5.29.0
+      undici: 6.24.0
 
   '@connectrpc/connect@1.7.0(@bufbuild/protobuf@1.10.0)':
     dependencies:
@@ -4095,7 +4203,7 @@ snapshots:
       semver: 7.7.4
       sumchecker: 3.0.1
     optionalDependencies:
-      undici: 7.24.6
+      undici: 7.28.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4181,96 +4289,94 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@exodus/bytes@1.15.0(@noble/hashes@2.0.1)':
     optionalDependencies:
       '@noble/hashes': 2.0.1
 
-  '@fastify/busboy@2.1.1': {}
-
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
 
   '@img/colour@1.1.0': {}
 
@@ -4387,7 +4493,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -4397,7 +4503,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -4425,10 +4531,15 @@ snapshots:
       rimraf: 3.0.2
     optional: true
 
-  '@paperclipai/adapter-acpx-local@2026.609.0':
+  '@opentelemetry/api@1.9.1':
+    optional: true
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@paperclipai/adapter-acpx-local@2026.618.0':
     dependencies:
       '@agentclientprotocol/claude-agent-acp': 0.31.4
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       '@zed-industries/codex-acp': 0.12.0
       acpx: 0.6.1
       picocolors: 1.1.1
@@ -4439,65 +4550,65 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@paperclipai/adapter-claude-local@2026.609.0':
+  '@paperclipai/adapter-claude-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-codex-local@2026.609.0':
+  '@paperclipai/adapter-codex-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-cursor-cloud@2026.609.0':
+  '@paperclipai/adapter-cursor-cloud@2026.618.0':
     dependencies:
       '@cursor/sdk': 1.0.18
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
     transitivePeerDependencies:
       - bluebird
       - supports-color
 
-  '@paperclipai/adapter-cursor-local@2026.609.0':
+  '@paperclipai/adapter-cursor-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-gemini-local@2026.609.0':
+  '@paperclipai/adapter-gemini-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-grok-local@2026.609.0':
+  '@paperclipai/adapter-grok-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-openclaw-gateway@2026.609.0':
+  '@paperclipai/adapter-openclaw-gateway@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@paperclipai/adapter-opencode-local@2026.609.0':
+  '@paperclipai/adapter-opencode-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-pi-local@2026.609.0':
+  '@paperclipai/adapter-pi-local@2026.618.0':
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  '@paperclipai/adapter-utils@2026.609.0': {}
+  '@paperclipai/adapter-utils@2026.618.0': {}
 
-  '@paperclipai/db@2026.609.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)':
+  '@paperclipai/db@2026.618.0(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(sqlite3@5.1.7)':
     dependencies:
-      '@paperclipai/shared': 2026.609.0
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
+      '@paperclipai/shared': 2026.618.0
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
       postgres: 3.4.9
     transitivePeerDependencies:
@@ -4531,47 +4642,47 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@paperclipai/plugin-sdk@2026.609.0':
+  '@paperclipai/plugin-sdk@2026.618.0':
     dependencies:
-      '@paperclipai/shared': 2026.609.0
+      '@paperclipai/shared': 2026.618.0
       zod: 3.25.76
 
-  '@paperclipai/server@2026.609.0(@noble/hashes@2.0.1)(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)':
+  '@paperclipai/server@2026.618.0(@noble/hashes@2.0.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)':
     dependencies:
       '@aws-sdk/client-s3': 3.1017.0
-      '@paperclipai/adapter-acpx-local': 2026.609.0
-      '@paperclipai/adapter-claude-local': 2026.609.0
-      '@paperclipai/adapter-codex-local': 2026.609.0
-      '@paperclipai/adapter-cursor-cloud': 2026.609.0
-      '@paperclipai/adapter-cursor-local': 2026.609.0
-      '@paperclipai/adapter-gemini-local': 2026.609.0
-      '@paperclipai/adapter-grok-local': 2026.609.0
-      '@paperclipai/adapter-openclaw-gateway': 2026.609.0
-      '@paperclipai/adapter-opencode-local': 2026.609.0
-      '@paperclipai/adapter-pi-local': 2026.609.0
-      '@paperclipai/adapter-utils': 2026.609.0
-      '@paperclipai/db': 2026.609.0(kysely@0.28.14)(pg@8.20.0)(sqlite3@5.1.7)
-      '@paperclipai/plugin-sdk': 2026.609.0
-      '@paperclipai/shared': 2026.609.0
+      '@paperclipai/adapter-acpx-local': 2026.618.0
+      '@paperclipai/adapter-claude-local': 2026.618.0
+      '@paperclipai/adapter-codex-local': 2026.618.0
+      '@paperclipai/adapter-cursor-cloud': 2026.618.0
+      '@paperclipai/adapter-cursor-local': 2026.618.0
+      '@paperclipai/adapter-gemini-local': 2026.618.0
+      '@paperclipai/adapter-grok-local': 2026.618.0
+      '@paperclipai/adapter-openclaw-gateway': 2026.618.0
+      '@paperclipai/adapter-opencode-local': 2026.618.0
+      '@paperclipai/adapter-pi-local': 2026.618.0
+      '@paperclipai/adapter-utils': 2026.618.0
+      '@paperclipai/db': 2026.618.0(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(sqlite3@5.1.7)
+      '@paperclipai/plugin-sdk': 2026.618.0
+      '@paperclipai/shared': 2026.618.0
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      better-auth: 1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0)
+      better-auth: 1.6.11(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0)
       chokidar: 4.0.3
       detect-port: 2.1.0
-      dompurify: 3.4.2
+      dompurify: 3.4.11
       dotenv: 17.3.1
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       embedded-postgres: 18.1.0-beta.16
       express: 5.2.1
       hermes-paperclip-adapter: 0.2.1
       jsdom: 28.1.0(@noble/hashes@2.0.1)
-      multer: 2.1.1
+      multer: 2.2.0
       open: 11.0.0
       pino: 9.14.0
       pino-http: 10.5.0
       pino-pretty: 13.1.3
       sharp: 0.34.5
-      ws: 8.20.0
+      ws: 8.21.0
       zod: 3.25.76
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -4629,7 +4740,7 @@ snapshots:
       - vitest
       - vue
 
-  '@paperclipai/shared@2026.609.0':
+  '@paperclipai/shared@2026.618.0':
     dependencies:
       zod: 3.25.76
 
@@ -4988,7 +5099,7 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tootallnate/once@1.1.2':
+  '@tootallnate/once@2.0.1':
     optional: true
 
   '@types/cacheable-request@6.0.3':
@@ -5129,7 +5240,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5169,7 +5280,7 @@ snapshots:
       hosted-git-info: 4.1.0
       isbinaryfile: 5.0.7
       jiti: 2.7.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       json5: 2.2.3
       lazy-val: 1.0.5
       minimatch: 10.2.4
@@ -5177,7 +5288,7 @@ snapshots:
       proper-lockfile: 4.1.2
       resedit: 1.7.2
       semver: 7.7.4
-      tar: 7.5.14
+      tar: 7.5.16
       temp-file: 3.4.0
       tiny-async-pool: 1.3.0
       which: 5.0.0
@@ -5253,30 +5364,38 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-auth@1.4.18(drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0):
+  better-auth@1.6.11(@opentelemetry/api@1.9.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))(pg@8.20.0):
     dependencies:
-      '@better-auth/core': 1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
-      '@better-auth/telemetry': 1.4.18(@better-auth/core@1.4.18(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))
-      '@better-auth/utils': 0.3.0
+      '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0)
+      '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7))
+      '@better-auth/kysely-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/mongo-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/prisma-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)
+      '@better-auth/telemetry': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.2)(kysely@0.28.17)(nanostores@1.2.0))(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       '@noble/ciphers': 2.1.1
       '@noble/hashes': 2.0.1
-      better-call: 1.1.8(zod@4.3.6)
+      better-call: 1.3.5(zod@4.3.6)
       defu: 6.1.7
       jose: 6.2.2
-      kysely: 0.28.14
+      kysely: 0.28.17
       nanostores: 1.2.0
       zod: 4.3.6
     optionalDependencies:
-      drizzle-orm: 0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
+      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7)
       pg: 8.20.0
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
 
-  better-call@1.1.8(zod@4.3.6):
+  better-call@1.3.5(zod@4.3.6):
     dependencies:
-      '@better-auth/utils': 0.3.0
+      '@better-auth/utils': 0.4.0
       '@better-fetch/fetch': 1.1.21
       rou3: 0.7.12
-      set-cookie-parser: 2.7.2
+      set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.3.6
 
@@ -5302,7 +5421,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.0
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -5322,7 +5441,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5352,7 +5471,7 @@ snapshots:
       fs-extra: 10.1.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       sanitize-filename: 1.6.4
       source-map-support: 0.5.21
       stat-mode: 1.0.0
@@ -5389,7 +5508,7 @@ snapshots:
       promise-inflight: 1.0.1
       rimraf: 3.0.2
       ssri: 8.0.1
-      tar: 6.2.1
+      tar: 7.5.16
       unique-filename: 1.1.1
     transitivePeerDependencies:
       - bluebird
@@ -5428,7 +5547,8 @@ snapshots:
 
   chownr@1.1.4: {}
 
-  chownr@2.0.0: {}
+  chownr@2.0.0:
+    optional: true
 
   chownr@3.0.0: {}
 
@@ -5610,7 +5730,7 @@ snapshots:
       builder-util: 26.8.1
       fs-extra: 10.1.0
       iconv-lite: 0.6.3
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
     optionalDependencies:
       dmg-license: 1.0.11
     transitivePeerDependencies:
@@ -5629,7 +5749,7 @@ snapshots:
       verror: 1.10.1
     optional: true
 
-  dompurify@3.4.2:
+  dompurify@3.4.11:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -5641,9 +5761,10 @@ snapshots:
 
   dotenv@17.3.1: {}
 
-  drizzle-orm@0.45.2(kysely@0.28.14)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7):
+  drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.17)(pg@8.20.0)(postgres@3.4.9)(sqlite3@5.1.7):
     optionalDependencies:
-      kysely: 0.28.14
+      '@opentelemetry/api': 1.9.1
+      kysely: 0.28.17
       pg: 8.20.0
       postgres: 3.4.9
       sqlite3: 5.1.7
@@ -5693,7 +5814,7 @@ snapshots:
       builder-util: 26.8.1
       builder-util-runtime: 9.5.1
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -5704,7 +5825,7 @@ snapshots:
     dependencies:
       builder-util-runtime: 9.5.1
       fs-extra: 10.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       lazy-val: 1.0.5
       lodash.escaperegexp: 4.1.2
       lodash.isequal: 4.5.0
@@ -5783,39 +5904,39 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es6-error@4.1.1:
     optional: true
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -5869,7 +5990,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.0
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -5899,7 +6020,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -5937,12 +6058,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -5985,6 +6106,7 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
+    optional: true
 
   fs.realpath@1.0.0: {}
 
@@ -6098,14 +6220,18 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   help-me@5.0.0: {}
 
   hermes-paperclip-adapter@0.2.1:
     dependencies:
-      '@paperclipai/adapter-utils': 2026.609.0
+      '@paperclipai/adapter-utils': 2026.618.0
       picocolors: 1.1.1
 
-  hono@4.12.18: {}
+  hono@4.12.25: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -6129,7 +6255,7 @@ snapshots:
 
   http-proxy-agent@4.0.1:
     dependencies:
-      '@tootallnate/once': 1.1.2
+      '@tootallnate/once': 2.0.1
       agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -6249,7 +6375,7 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6270,7 +6396,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.24.6
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -6312,7 +6438,7 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  kysely@0.28.14: {}
+  kysely@0.28.17: {}
 
   lazy-val@1.0.5: {}
 
@@ -6388,7 +6514,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@3.1.5:
     dependencies:
@@ -6436,8 +6562,7 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-
-  minipass@5.0.0: {}
+    optional: true
 
   minipass@7.1.3: {}
 
@@ -6445,6 +6570,7 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
+    optional: true
 
   minizlib@3.1.0:
     dependencies:
@@ -6456,11 +6582,12 @@ snapshots:
     dependencies:
       minimist: 1.2.8
 
-  mkdirp@1.0.4: {}
+  mkdirp@1.0.4:
+    optional: true
 
   ms@2.1.3: {}
 
-  multer@2.1.1:
+  multer@2.2.0:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
@@ -6501,7 +6628,7 @@ snapshots:
       nopt: 9.0.0
       proc-log: 6.1.0
       semver: 7.7.4
-      tar: 7.5.14
+      tar: 7.5.16
       tinyglobby: 0.2.16
       undici: 6.25.0
       which: 6.0.1
@@ -6516,7 +6643,7 @@ snapshots:
       npmlog: 6.0.2
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 6.2.1
+      tar: 7.5.16
       which: 2.0.2
     transitivePeerDependencies:
       - bluebird
@@ -6755,7 +6882,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.0:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -6906,7 +7033,7 @@ snapshots:
   set-blocking@2.0.0:
     optional: true
 
-  set-cookie-parser@2.7.2: {}
+  set-cookie-parser@3.1.0: {}
 
   setprototypeof@1.2.0: {}
 
@@ -7048,7 +7175,7 @@ snapshots:
       bindings: 1.5.0
       node-addon-api: 7.1.1
       prebuild-install: 7.1.3
-      tar: 6.2.1
+      tar: 7.5.16
     optionalDependencies:
       node-gyp: 8.4.1
     transitivePeerDependencies:
@@ -7133,16 +7260,7 @@ snapshots:
       - bare-buffer
       - react-native-b4a
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
-  tar@7.5.14:
+  tar@7.5.16:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -7196,9 +7314,9 @@ snapshots:
 
   tmp-promise@3.0.3:
     dependencies:
-      tmp: 0.2.5
+      tmp: 0.2.7
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   toidentifier@1.0.1: {}
 
@@ -7222,7 +7340,7 @@ snapshots:
 
   tsx@4.21.0:
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       get-tsconfig: 4.14.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -7253,13 +7371,11 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@5.29.0:
-    dependencies:
-      '@fastify/busboy': 2.1.1
+  undici@6.24.0: {}
 
   undici@6.25.0: {}
 
-  undici@7.24.6: {}
+  undici@7.28.0: {}
 
   unique-filename@1.1.1:
     dependencies:
@@ -7335,7 +7451,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/scripts/after-pack.mjs
+++ b/scripts/after-pack.mjs
@@ -103,6 +103,56 @@ function collectSignableBinaries(dir, out = []) {
   return out;
 }
 
+function walkBundleEntries(dir, visit) {
+  if (!existsSync(dir)) return;
+
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = join(dir, entry);
+
+    let stat;
+    try {
+      stat = lstatSync(full);
+    } catch {
+      continue;
+    }
+
+    visit(full, entry, stat);
+
+    if (!stat.isSymbolicLink() && stat.isDirectory()) {
+      walkBundleEntries(full, visit);
+    }
+  }
+}
+
+function removeFinderMetadata(root) {
+  walkBundleEntries(root, (full, entry) => {
+    if (entry === ".DS_Store" || entry.startsWith("._")) {
+      rmSync(full, { force: true });
+    }
+  });
+}
+
+function clearExtendedAttributes(root) {
+  walkBundleEntries(root, (full, _entry, stat) => {
+    if (stat.isSymbolicLink()) {
+      return;
+    }
+
+    try {
+      execFileSync("xattr", ["-c", full], { stdio: "ignore" });
+    } catch {
+      // best effort only
+    }
+  });
+}
+
 function stripBundleMetadata(appPath) {
   console.log("[after-pack] Cleaning broken symlinks...");
   removeBrokenSymlinks(join(appPath, "Contents"));
@@ -113,10 +163,10 @@ function stripBundleMetadata(appPath) {
   } catch {
     // best effort only
   }
-  execFileSync("sh", ["-c", `find "${appPath}" -name "._*" -delete 2>/dev/null; find "${appPath}" -name ".DS_Store" -delete 2>/dev/null; true`]);
+  removeFinderMetadata(appPath);
 
   console.log("[after-pack] Stripping extended attributes...");
-  execFileSync("sh", ["-c", `find "${appPath}" ! -type l -print0 | xargs -0 -n 200 xattr -c 2>/dev/null; true`]);
+  clearExtendedAttributes(appPath);
 }
 
 function signTarget(target, identity, entitlements) {

--- a/scripts/after-pack.mjs
+++ b/scripts/after-pack.mjs
@@ -139,18 +139,34 @@ function removeFinderMetadata(root) {
   });
 }
 
+function clearExtendedAttributeBatch(paths) {
+  if (paths.length === 0) {
+    return;
+  }
+
+  try {
+    execFileSync("xattr", ["-c", ...paths], { stdio: "ignore" });
+  } catch {
+    // best effort only
+  }
+}
+
 function clearExtendedAttributes(root) {
+  let batch = [root];
+
   walkBundleEntries(root, (full, _entry, stat) => {
     if (stat.isSymbolicLink()) {
       return;
     }
 
-    try {
-      execFileSync("xattr", ["-c", full], { stdio: "ignore" });
-    } catch {
-      // best effort only
+    batch.push(full);
+    if (batch.length >= 100) {
+      clearExtendedAttributeBatch(batch);
+      batch = [];
     }
   });
+
+  clearExtendedAttributeBatch(batch);
 }
 
 function stripBundleMetadata(appPath) {

--- a/scripts/build-ui.mjs
+++ b/scripts/build-ui.mjs
@@ -11,7 +11,7 @@
  * be simplified to just copy from node_modules.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, mkdirSync, rmSync, cpSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -58,7 +58,7 @@ if (!serverVersion) {
 // ── Try to install @paperclipai/ui from npm first (future-proofing) ─────────
 
 try {
-  const uiVersion = execSync(`npm view @paperclipai/ui@${serverVersion} version`, {
+  const uiVersion = execFileSync("npm", ["view", `@paperclipai/ui@${serverVersion}`, "version"], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     timeout: 15000,
@@ -69,13 +69,15 @@ try {
     const uiStagingDir = path.join(projectRoot, "build", "ui-staging");
     if (existsSync(uiStagingDir)) rmSync(uiStagingDir, { recursive: true, force: true });
     mkdirSync(uiStagingDir, { recursive: true });
-    execSync(`npm pack @paperclipai/ui@${uiVersion} --pack-destination "${uiStagingDir}"`, { stdio: "inherit" });
+    execFileSync("npm", ["pack", `@paperclipai/ui@${uiVersion}`, "--pack-destination", uiStagingDir], {
+      stdio: "inherit",
+    });
     // Extract and copy dist/
     const tarballs = readdirSync(uiStagingDir)
       .filter((entry) => entry.endsWith(".tgz"))
       .map((entry) => path.join(uiStagingDir, entry));
     if (tarballs[0]) {
-      execSync(`tar -xzf "${tarballs[0]}" -C "${uiStagingDir}"`, { stdio: "inherit" });
+      execFileSync("tar", ["-xzf", tarballs[0], "-C", uiStagingDir], { stdio: "inherit" });
       const uiDist = path.join(uiStagingDir, "package", "dist");
       if (existsSync(path.join(uiDist, "index.html"))) {
         copyUiDistToBundles(uiDist);
@@ -104,8 +106,9 @@ let cloneSuccess = false;
 for (const tag of tagCandidates) {
   try {
     console.log(`[build-ui] Cloning upstream at tag ${tag}...`);
-    execSync(
-      `git clone --depth 1 --branch "${tag}" https://github.com/paperclipai/paperclip.git "${cloneDir}"`,
+    execFileSync(
+      "git",
+      ["clone", "--depth", "1", "--branch", tag, "https://github.com/paperclipai/paperclip.git", cloneDir],
       { stdio: "inherit", timeout: 120000 },
     );
     cloneSuccess = true;
@@ -124,10 +127,10 @@ if (!cloneSuccess) {
 // ── Install dependencies and build UI ───────────────────────────────────────
 
 console.log("[build-ui] Installing upstream dependencies...");
-execSync("pnpm install --frozen-lockfile", { cwd: cloneDir, stdio: "inherit", timeout: 300000 });
+execFileSync("pnpm", ["install", "--frozen-lockfile"], { cwd: cloneDir, stdio: "inherit", timeout: 300000 });
 
 console.log("[build-ui] Building UI...");
-execSync("pnpm --filter @paperclipai/ui build", { cwd: cloneDir, stdio: "inherit", timeout: 300000 });
+execFileSync("pnpm", ["--filter", "@paperclipai/ui", "build"], { cwd: cloneDir, stdio: "inherit", timeout: 300000 });
 
 // ── Copy UI dist to server bundle ───────────────────────────────────────────
 

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -6,7 +6,7 @@
  * into the app.
  */
 
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import {
   cpSync,
   existsSync,
@@ -180,8 +180,9 @@ for (const arch of targetArches) {
     ),
   );
 
-  execSync(
-    `npm install --production --os=${nodePlatform} --cpu=${arch} --arch=${arch}`,
+  execFileSync(
+    "npm",
+    ["install", "--production", `--os=${nodePlatform}`, `--cpu=${arch}`, `--arch=${arch}`],
     {
       cwd: stagingDir,
       stdio: "inherit",
@@ -251,17 +252,29 @@ for (const arch of arches) {
   console.log(`[prepare-server] Downloading Node ${NODE_VERSION} for ${nodeDownloadPlatform}-${arch}...`);
 
   if (platform === "win32") {
-    execSync(`powershell -Command "Invoke-WebRequest -Uri '${url}' -OutFile '${archivePath}'"`, { stdio: "inherit" });
+    execFileSync(
+      "powershell",
+      ["-NoProfile", "-Command", "Invoke-WebRequest -Uri $args[0] -OutFile $args[1]", url, archivePath],
+      { stdio: "inherit" },
+    );
   } else {
-    execSync(`curl -fsSL -o "${archivePath}" "${url}"`, { stdio: "inherit" });
+    execFileSync("curl", ["-fsSL", "-o", archivePath, url], { stdio: "inherit" });
   }
 
   if (platform === "win32") {
-    execSync(`powershell -Command "Expand-Archive -Path '${archivePath}' -DestinationPath '${destDir}' -Force"`, { stdio: "inherit" });
+    execFileSync(
+      "powershell",
+      ["-NoProfile", "-Command", "Expand-Archive -Path $args[0] -DestinationPath $args[1] -Force", archivePath, destDir],
+      { stdio: "inherit" },
+    );
     cpSync(path.join(destDir, archiveName, "node.exe"), destBin);
     rmSync(path.join(destDir, archiveName), { recursive: true, force: true });
   } else {
-    execSync(`tar -xzf "${archivePath}" -C "${destDir}" --strip-components=2 "${archiveName}/bin/node"`, { stdio: "inherit" });
+    execFileSync(
+      "tar",
+      ["-xzf", archivePath, "-C", destDir, "--strip-components=2", `${archiveName}/bin/node`],
+      { stdio: "inherit" },
+    );
   }
 
   rmSync(archivePath, { force: true });

--- a/scripts/prepare-server.mjs
+++ b/scripts/prepare-server.mjs
@@ -34,6 +34,13 @@ if (!serverVersion) {
   process.exit(1);
 }
 
+const serverBundleOverrides = {
+  ...(projectPkg.pnpm?.overrides ?? {}),
+  // cssstyle currently resolves a 5.x css-color release that trips
+  // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
+  "@asamuzakjp/css-color": "4.1.2",
+};
+
 console.log(`[prepare-server] Target server version: @paperclipai/server@${serverVersion}`);
 
 const platform = process.platform;
@@ -169,11 +176,7 @@ for (const arch of targetArches) {
       {
         private: true,
         dependencies: { "@paperclipai/server": serverVersion },
-        overrides: {
-          // cssstyle currently resolves a 5.x css-color release that trips
-          // Node 22's ERR_REQUIRE_ASYNC_MODULE path in the packaged runtime.
-          "@asamuzakjp/css-color": "4.1.2",
-        },
+        overrides: serverBundleOverrides,
       },
       null,
       2,

--- a/scripts/stage-after-pack.mjs
+++ b/scripts/stage-after-pack.mjs
@@ -55,6 +55,49 @@ function removeBrokenSymlinks(dir) {
   }
 }
 
+function walkBundleEntries(dir, visit) {
+  if (!existsSync(dir)) return;
+
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let stat;
+
+    try {
+      stat = lstatSync(full);
+    } catch {
+      continue;
+    }
+
+    visit(full, entry, stat);
+
+    if (!stat.isSymbolicLink() && stat.isDirectory()) {
+      walkBundleEntries(full, visit);
+    }
+  }
+}
+
+function removeFinderMetadata(root) {
+  walkBundleEntries(root, (full, entry) => {
+    if (entry === ".DS_Store" || entry.startsWith("._")) {
+      rmSync(full, { force: true });
+    }
+  });
+}
+
+function clearExtendedAttributes(root) {
+  walkBundleEntries(root, (full, _entry, stat) => {
+    if (stat.isSymbolicLink()) {
+      return;
+    }
+
+    try {
+      execFileSync("xattr", ["-c", full], { stdio: "ignore" });
+    } catch {
+      // Best effort only.
+    }
+  });
+}
+
 function stripBundleMetadata(appPath) {
   removeBrokenSymlinks(join(appPath, "Contents"));
 
@@ -64,8 +107,8 @@ function stripBundleMetadata(appPath) {
     // Best effort only.
   }
 
-  execFileSync("sh", ["-c", `find "${appPath}" -name "._*" -delete 2>/dev/null; find "${appPath}" -name ".DS_Store" -delete 2>/dev/null; true`]);
-  execFileSync("sh", ["-c", `find "${appPath}" ! -type l -print0 | xargs -0 -n 200 xattr -c 2>/dev/null; true`]);
+  removeFinderMetadata(appPath);
+  clearExtendedAttributes(appPath);
 }
 
 function dereferenceSymlinks(dir) {

--- a/scripts/stage-after-pack.mjs
+++ b/scripts/stage-after-pack.mjs
@@ -84,18 +84,34 @@ function removeFinderMetadata(root) {
   });
 }
 
+function clearExtendedAttributeBatch(paths) {
+  if (paths.length === 0) {
+    return;
+  }
+
+  try {
+    execFileSync("xattr", ["-c", ...paths], { stdio: "ignore" });
+  } catch {
+    // Best effort only.
+  }
+}
+
 function clearExtendedAttributes(root) {
+  let batch = [root];
+
   walkBundleEntries(root, (full, _entry, stat) => {
     if (stat.isSymbolicLink()) {
       return;
     }
 
-    try {
-      execFileSync("xattr", ["-c", full], { stdio: "ignore" });
-    } catch {
-      // Best effort only.
+    batch.push(full);
+    if (batch.length >= 100) {
+      clearExtendedAttributeBatch(batch);
+      batch = [];
     }
   });
+
+  clearExtendedAttributeBatch(batch);
 }
 
 function stripBundleMetadata(appPath) {

--- a/src/launcher-html.ts
+++ b/src/launcher-html.ts
@@ -1961,7 +1961,15 @@ function escapeAttr(value) {
 }
 
 function escapeJsSingleQuote(value) {
-  return String(value).replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+  return escapeAttr(
+    String(value)
+      .replaceAll("\\", "\\\\")
+      .replaceAll("'", "\\'")
+      .replaceAll("\n", "\\n")
+      .replaceAll("\r", "\\r")
+      .replaceAll("\u2028", "\\u2028")
+      .replaceAll("\u2029", "\\u2029"),
+  );
 }
 
 function measureLauncherHeight(windowEl) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ import {
   type MenuItemConstructorOptions,
   type Session,
 } from "electron";
-import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import net from "node:net";
@@ -309,8 +309,10 @@ function resolveShellPath(): string {
 
   let basePath = process.env.PATH ?? "";
   try {
-    const userShell = process.env.SHELL || "/bin/zsh";
-    const shellPath = execSync(`${userShell} -lc 'echo $PATH'`, {
+    const userShell = process.env.SHELL && path.isAbsolute(process.env.SHELL)
+      ? process.env.SHELL
+      : "/bin/zsh";
+    const shellPath = execFileSync(userShell, ["-lc", "echo $PATH"], {
       encoding: "utf8",
       timeout: 5_000,
       stdio: ["ignore", "pipe", "ignore"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,6 +60,8 @@ const LOCAL_SERVER_HEALTH_POLL_INTERVAL_MS = 30_000;
 const LOCAL_SERVER_HEALTH_TIMEOUT_MS = 5_000;
 const SERVER_LOG_MAX_BYTES = 20 * 1024 * 1024;
 const SERVER_LOG_ARCHIVE_KEEP = 5;
+const SERVER_LOG_ARCHIVE_PREFIX = "server.log.";
+const SERVER_LOG_UNSAFE_PREFIX = "server.log.unsafe.";
 
 // ---------------------------------------------------------------------------
 // Process-global state
@@ -367,29 +369,77 @@ function killOrphanedServer(): void {
   cleanupPidFile();
 }
 
+function serverLogArchiveDir(logFile: string): string {
+  return path.join(path.dirname(logFile), "log-archive");
+}
+
+function serverLogArchivePath(logFile: string, prefix: string): string {
+  const stamp = new Date()
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace("T", "-")
+    .replace(".", "-");
+  return path.join(serverLogArchiveDir(logFile), `${prefix}${stamp}.${randomUUID()}`);
+}
+
+function archiveServerLogPath(logFile: string, prefix: string = SERVER_LOG_ARCHIVE_PREFIX): void {
+  const archiveDir = serverLogArchiveDir(logFile);
+  fs.mkdirSync(archiveDir, { recursive: true });
+  fs.renameSync(logFile, serverLogArchivePath(logFile, prefix));
+}
+
+function quarantineUnsafeServerLogPath(logFile: string): void {
+  try {
+    const stats = fs.lstatSync(logFile);
+    if (stats.isFile()) {
+      return;
+    }
+
+    archiveServerLogPath(logFile, SERVER_LOG_UNSAFE_PREFIX);
+  } catch {
+    // ignore
+  }
+}
+
+function pruneServerLogArchives(logFile: string): void {
+  try {
+    const archiveDir = serverLogArchiveDir(logFile);
+    const archives = fs
+      .readdirSync(archiveDir)
+      .filter((name) => {
+        if (!name.startsWith(SERVER_LOG_ARCHIVE_PREFIX)) {
+          return false;
+        }
+
+        try {
+          return fs.lstatSync(path.join(archiveDir, name)).isFile();
+        } catch {
+          return false;
+        }
+      })
+      .sort();
+
+    for (const stale of archives.slice(0, Math.max(0, archives.length - SERVER_LOG_ARCHIVE_KEEP))) {
+      fs.unlinkSync(path.join(archiveDir, stale));
+    }
+  } catch {
+    // ignore
+  }
+}
+
 function rotateServerLogIfLarge(logFile: string): void {
   try {
-    const stats = fs.statSync(logFile);
+    const stats = fs.lstatSync(logFile);
+    if (!stats.isFile()) {
+      return;
+    }
+
     if (stats.size < SERVER_LOG_MAX_BYTES) {
       return;
     }
 
-    const archiveDir = path.join(path.dirname(logFile), "log-archive");
-    fs.mkdirSync(archiveDir, { recursive: true });
-    const stamp = new Date()
-      .toISOString()
-      .replace(/[-:]/g, "")
-      .replace("T", "-")
-      .slice(0, 15);
-    fs.renameSync(logFile, path.join(archiveDir, `server.log.${stamp}`));
-
-    const archives = fs
-      .readdirSync(archiveDir)
-      .filter((name) => name.startsWith("server.log."))
-      .sort();
-    for (const stale of archives.slice(0, Math.max(0, archives.length - SERVER_LOG_ARCHIVE_KEEP))) {
-      fs.unlinkSync(path.join(archiveDir, stale));
-    }
+    archiveServerLogPath(logFile);
+    pruneServerLogArchives(logFile);
   } catch {
     // ignore
   }
@@ -1014,6 +1064,7 @@ async function bootLocal(options: {
     trackServerProcess(nextServerProcess);
 
     const logFile = path.join(app.getPath("userData"), "server.log");
+    quarantineUnsafeServerLogPath(logFile);
     rotateServerLogIfLarge(logFile);
     const logStream = fs.createWriteStream(logFile, { flags: "a" });
     logStream.write(`\n--- Server start ${new Date().toISOString()} (port=${serverPort}) ---\n`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -73,6 +73,8 @@ let launcherPresentation: LauncherPresentation = "standalone";
 let isQuitting = false;
 let bootSequence = 0;
 let launcherView: LauncherView = "chooser";
+let appStartupReadyForFocus = false;
+let pendingSecondInstanceFocus = false;
 let localServerMonitorTimer: ReturnType<typeof setInterval> | null = null;
 let localServerHealthCheckInFlight = false;
 let localServerFailureDialogOpen = false;
@@ -103,30 +105,47 @@ applyDesktopUserDataOverride(app, process.env);
 // macOS crash reporter still leave evidence in app.getPath("crashDumps").
 crashReporter.start({ uploadToServer: false });
 
+function focusExistingInstanceWindow(): void {
+  if (!appStartupReadyForFocus) {
+    pendingSecondInstanceFocus = true;
+    return;
+  }
+
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    if (mainWindow.isMinimized()) {
+      mainWindow.restore();
+    }
+    mainWindow.show();
+    mainWindow.focus();
+    return;
+  }
+
+  if (launcherWindow && !launcherWindow.isDestroyed()) {
+    launcherWindow.show();
+    launcherWindow.focus();
+    return;
+  }
+
+  void ensureLauncherWindow("chooser");
+}
+
+function markAppStartupReadyForFocus(): void {
+  appStartupReadyForFocus = true;
+  if (!pendingSecondInstanceFocus) {
+    return;
+  }
+
+  pendingSecondInstanceFocus = false;
+  focusExistingInstanceWindow();
+}
+
 // A second app instance must never boot its own embedded server against the
 // same PAPERCLIP_HOME/postgres data dir — focus the existing instance instead.
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 if (!hasSingleInstanceLock) {
   app.quit();
 } else {
-  app.on("second-instance", () => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      if (mainWindow.isMinimized()) {
-        mainWindow.restore();
-      }
-      mainWindow.show();
-      mainWindow.focus();
-      return;
-    }
-
-    if (launcherWindow && !launcherWindow.isDestroyed()) {
-      launcherWindow.show();
-      launcherWindow.focus();
-      return;
-    }
-
-    void ensureLauncherWindow("chooser");
-  });
+  app.on("second-instance", focusExistingInstanceWindow);
 }
 
 // ---------------------------------------------------------------------------
@@ -1610,6 +1629,7 @@ app.whenReady().then(async () => {
   if (startupProfileId) {
     if (startupProfileId === LOCAL_PROFILE_ID) {
       await ensureLauncherWindow("local-boot");
+      markAppStartupReadyForFocus();
       void bootLocal();
       return;
     }
@@ -1620,6 +1640,7 @@ app.whenReady().then(async () => {
         label: "Opening verified remote...",
         url: profile.remoteUrl,
       });
+      markAppStartupReadyForFocus();
       void bootSavedProfile(startupProfileId);
       return;
     }
@@ -1627,9 +1648,15 @@ app.whenReady().then(async () => {
 
   connectionStore.setChooserMode("local_embedded");
   await ensureLauncherWindow("chooser");
+  markAppStartupReadyForFocus();
 });
 
 app.on("activate", () => {
+  if (!appStartupReadyForFocus) {
+    pendingSecondInstanceFocus = true;
+    return;
+  }
+
   if (launcherWindow && !launcherWindow.isDestroyed()) {
     launcherWindow.show();
     launcherWindow.focus();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 import {
   app,
   BrowserWindow,
+  crashReporter,
   dialog,
   ipcMain,
   Menu,
@@ -57,6 +58,8 @@ const POLL_INTERVAL_MS = 400;
 const PID_FILE_NAME = "paperclip-electron.pid";
 const LOCAL_SERVER_HEALTH_POLL_INTERVAL_MS = 30_000;
 const LOCAL_SERVER_HEALTH_TIMEOUT_MS = 5_000;
+const SERVER_LOG_MAX_BYTES = 20 * 1024 * 1024;
+const SERVER_LOG_ARCHIVE_KEEP = 5;
 
 // ---------------------------------------------------------------------------
 // Process-global state
@@ -95,6 +98,36 @@ type BootStep = "init" | "database" | "server" | "ready";
 
 app.setName("Paperclip");
 applyDesktopUserDataOverride(app, process.env);
+
+// Capture native crashes locally (no upload) so segfaults that bypass the
+// macOS crash reporter still leave evidence in app.getPath("crashDumps").
+crashReporter.start({ uploadToServer: false });
+
+// A second app instance must never boot its own embedded server against the
+// same PAPERCLIP_HOME/postgres data dir — focus the existing instance instead.
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
+if (!hasSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on("second-instance", () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
+      mainWindow.show();
+      mainWindow.focus();
+      return;
+    }
+
+    if (launcherWindow && !launcherWindow.isDestroyed()) {
+      launcherWindow.show();
+      launcherWindow.focus();
+      return;
+    }
+
+    void ensureLauncherWindow("chooser");
+  });
+}
 
 // ---------------------------------------------------------------------------
 // Paths and version helpers
@@ -311,6 +344,34 @@ function killOrphanedServer(): void {
   }
 
   cleanupPidFile();
+}
+
+function rotateServerLogIfLarge(logFile: string): void {
+  try {
+    const stats = fs.statSync(logFile);
+    if (stats.size < SERVER_LOG_MAX_BYTES) {
+      return;
+    }
+
+    const archiveDir = path.join(path.dirname(logFile), "log-archive");
+    fs.mkdirSync(archiveDir, { recursive: true });
+    const stamp = new Date()
+      .toISOString()
+      .replace(/[-:]/g, "")
+      .replace("T", "-")
+      .slice(0, 15);
+    fs.renameSync(logFile, path.join(archiveDir, `server.log.${stamp}`));
+
+    const archives = fs
+      .readdirSync(archiveDir)
+      .filter((name) => name.startsWith("server.log."))
+      .sort();
+    for (const stale of archives.slice(0, Math.max(0, archives.length - SERVER_LOG_ARCHIVE_KEEP))) {
+      fs.unlinkSync(path.join(archiveDir, stale));
+    }
+  } catch {
+    // ignore
+  }
 }
 
 function resolvePaperclipHome(): string {
@@ -932,6 +993,7 @@ async function bootLocal(options: {
     trackServerProcess(nextServerProcess);
 
     const logFile = path.join(app.getPath("userData"), "server.log");
+    rotateServerLogIfLarge(logFile);
     const logStream = fs.createWriteStream(logFile, { flags: "a" });
     logStream.write(`\n--- Server start ${new Date().toISOString()} (port=${serverPort}) ---\n`);
 
@@ -1526,6 +1588,10 @@ function remoteErrorTitle(result: RemotePreflightResult): string {
 // ---------------------------------------------------------------------------
 
 app.whenReady().then(async () => {
+  if (!hasSingleInstanceLock) {
+    return;
+  }
+
   const paperclipHome = resolvePaperclipHome();
   assertIsolatedRuntimePaths({
     env: process.env,

--- a/test/manual/dual-instance-e2e.mjs
+++ b/test/manual/dual-instance-e2e.mjs
@@ -91,10 +91,17 @@ try {
 
   await sleep(3_000);
   const secondBootedServer = /Server listening on|Using PAPERCLIP_HOME/.test(second.output);
+  const secondExitedCleanly = second.exited.code === 0 && second.exited.signal === null;
   const firstStillAlive = first.exitCode === null && !first.exited;
 
   if (secondBootedServer) {
     console.error("[dual-e2e] FAIL: second instance attempted to boot a server:\n" + second.output.slice(-2000));
+    failed = true;
+  } else if (!secondExitedCleanly) {
+    console.error(
+      `[dual-e2e] FAIL: second instance exited unexpectedly (code=${second.exited.code}, signal=${second.exited.signal}):\n`
+        + second.output.slice(-2000),
+    );
     failed = true;
   } else if (!firstStillAlive) {
     console.error("[dual-e2e] FAIL: first instance died after second launch");

--- a/test/manual/dual-instance-e2e.mjs
+++ b/test/manual/dual-instance-e2e.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// End-to-end check for the single-instance lock: launch the packaged app
+// twice against the same isolated userData/PAPERCLIP_HOME and assert the
+// second launch exits without booting another embedded server.
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, readdirSync, writeFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const appArg = process.argv[2];
+if (!appArg) {
+  console.error("usage: dual-instance-e2e.mjs <path-to-.app>");
+  process.exit(2);
+}
+
+const macosDir = path.join(path.resolve(appArg), "Contents", "MacOS");
+const executable = path.join(macosDir, readdirSync(macosDir).filter((e) => !e.startsWith("."))[0]);
+
+const tempRoot = mkdtempSync(path.join(os.tmpdir(), "paperclip-dual-instance-"));
+const userDataDir = path.join(tempRoot, "user-data");
+const paperclipHome = path.join(tempRoot, "paperclip-home");
+mkdirSync(userDataDir, { recursive: true });
+mkdirSync(paperclipHome, { recursive: true });
+
+writeFileSync(
+  path.join(userDataDir, "connections.json"),
+  JSON.stringify({
+    version: 1,
+    state: {
+      activeProfileId: "local_embedded",
+      alwaysShowChooser: false,
+      autoConnectLastProfile: true,
+      chooserMode: "local_embedded",
+      localProfileName: "Local",
+      localLastHealth: "healthy",
+    },
+    remoteProfiles: [],
+  }, null, 2),
+  "utf8",
+);
+
+const env = {
+  ...process.env,
+  PAPERCLIP_DESKTOP_REQUIRE_ISOLATED_DATA: "1",
+  PAPERCLIP_DESKTOP_USER_DATA_DIR: userDataDir,
+  PAPERCLIP_HOME: paperclipHome,
+};
+
+function launch(label) {
+  const child = spawn(executable, [], { env, stdio: ["ignore", "pipe", "pipe"] });
+  child.output = "";
+  const collect = (chunk) => {
+    child.output += chunk.toString();
+  };
+  child.stdout.on("data", collect);
+  child.stderr.on("data", collect);
+  child.on("exit", (code, signal) => {
+    child.exited = { code, signal };
+    console.log(`[dual-e2e] ${label} exited (code=${code}, signal=${signal})`);
+  });
+  return child;
+}
+
+const waitFor = (pred, timeoutMs, what) =>
+  new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const tick = () => {
+      if (pred()) return resolve();
+      if (Date.now() > deadline) return reject(new Error(`timed out waiting for ${what}`));
+      setTimeout(tick, 250);
+    };
+    tick();
+  });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+let first;
+let second;
+let failed = false;
+
+try {
+  console.log("[dual-e2e] launching first instance...");
+  first = launch("first");
+  await waitFor(() => /Server listening on/.test(first.output), 120_000, "first instance server");
+  console.log("[dual-e2e] first instance server is up");
+
+  console.log("[dual-e2e] launching second instance...");
+  second = launch("second");
+
+  // The second instance should give up the single-instance lock and exit.
+  await waitFor(() => second.exited, 30_000, "second instance to exit");
+
+  await sleep(3_000);
+  const secondBootedServer = /Server listening on|Using PAPERCLIP_HOME/.test(second.output);
+  const firstStillAlive = first.exitCode === null && !first.exited;
+
+  if (secondBootedServer) {
+    console.error("[dual-e2e] FAIL: second instance attempted to boot a server:\n" + second.output.slice(-2000));
+    failed = true;
+  } else if (!firstStillAlive) {
+    console.error("[dual-e2e] FAIL: first instance died after second launch");
+    failed = true;
+  } else {
+    console.log("[dual-e2e] PASS: second instance exited without starting a server; first instance unaffected");
+  }
+} catch (error) {
+  console.error(`[dual-e2e] FAIL: ${error.message}`);
+  if (first) console.error("--- first output tail ---\n" + first.output.slice(-2000));
+  if (second) console.error("--- second output tail ---\n" + second.output.slice(-2000));
+  failed = true;
+} finally {
+  for (const child of [second, first]) {
+    if (child && child.exitCode === null && !child.exited) {
+      child.kill("SIGTERM");
+    }
+  }
+  await sleep(4_000);
+  rmSync(tempRoot, { recursive: true, force: true });
+}
+
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Summary
- add Electron crash dump capture, single-instance enforcement, safer server log rotation, and a packaged dual-instance E2E check
- patch audited vulnerable transitive dependencies and ensure the bundled server staging install receives the same security overrides
- remove shell interpolation from main-process PATH lookup and packaging/release scripts
- harden launcher profile id escaping in inline handlers

## Validation
- `pnpm audit --audit-level moderate`
- `pnpm audit --prod --audit-level moderate`
- `pnpm test:connections`
- `pnpm test:release-safety`
- `pnpm test:prepare-release-assets:mac`
- `pnpm prepare-server` (both x64 and arm64 staging installs: `found 0 vulnerabilities`)
- `ALLOW_UNSIGNED_MACOS_BUILD=true pnpm run pack`
- `node scripts/smoke-test-packaged-macos.mjs --app "release/mac/Paperclip Desktop.app" --timeout-ms 180000`
- `node test/manual/dual-instance-e2e.mjs "release/mac/Paperclip Desktop.app"`