### PR TITLE
Fix same-origin View run popups

### DIFF
--- a/src/connection/window-policy.ts
+++ b/src/connection/window-policy.ts
@@ -11,6 +11,10 @@ export interface WindowPolicy {
 export function isNavigationAllowed(targetUrl: string, allowedOrigin: string): boolean {
   try {
     const parsed = new URL(targetUrl);
+    if (hasEmbeddedCredentials(parsed)) {
+      return false;
+    }
+
     return parsed.origin === allowedOrigin;
   } catch {
     return false;
@@ -20,6 +24,10 @@ export function isNavigationAllowed(targetUrl: string, allowedOrigin: string): b
 export function shouldOpenExternally(targetUrl: string, allowedOrigin: string): boolean {
   try {
     const parsed = new URL(targetUrl);
+    if (hasEmbeddedCredentials(parsed)) {
+      return false;
+    }
+
     if (parsed.origin === allowedOrigin) {
       return false;
     }
@@ -35,6 +43,10 @@ export type NewWindowPolicyAction = "navigate-in-app" | "open-externally" | "den
 export function newWindowPolicyAction(targetUrl: string, allowedOrigin: string): NewWindowPolicyAction {
   try {
     const parsed = new URL(targetUrl);
+    if (hasEmbeddedCredentials(parsed)) {
+      return "deny";
+    }
+
     if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
       return "deny";
     }
@@ -47,6 +59,10 @@ export function newWindowPolicyAction(targetUrl: string, allowedOrigin: string):
   } catch {
     return "deny";
   }
+}
+
+function hasEmbeddedCredentials(parsed: URL): boolean {
+  return parsed.username !== "" || parsed.password !== "";
 }
 
 export function remotePartitionForProfile(profileId: string): string {

--- a/src/connection/window-policy.ts
+++ b/src/connection/window-policy.ts
@@ -30,6 +30,25 @@ export function shouldOpenExternally(targetUrl: string, allowedOrigin: string): 
   }
 }
 
+export type NewWindowPolicyAction = "navigate-in-app" | "open-externally" | "deny";
+
+export function newWindowPolicyAction(targetUrl: string, allowedOrigin: string): NewWindowPolicyAction {
+  try {
+    const parsed = new URL(targetUrl);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return "deny";
+    }
+
+    if (parsed.origin === allowedOrigin) {
+      return "navigate-in-app";
+    }
+
+    return "open-externally";
+  } catch {
+    return "deny";
+  }
+}
+
 export function remotePartitionForProfile(profileId: string): string {
   return `persist:paperclip-remote-${profileId}`;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
 import {
   isNavigationAllowed,
   localPartition,
+  newWindowPolicyAction,
   remotePartitionForProfile,
   shouldOpenExternally,
 } from "./connection/window-policy";
@@ -892,7 +893,10 @@ function applyWindowPolicy(win: BrowserWindow, allowedOrigin: string): void {
   });
 
   win.webContents.setWindowOpenHandler(({ url }) => {
-    if (shouldOpenExternally(url, allowedOrigin)) {
+    const action = newWindowPolicyAction(url, allowedOrigin);
+    if (action === "navigate-in-app") {
+      void win.webContents.loadURL(url);
+    } else if (action === "open-externally") {
       void shell.openExternal(url);
     }
     return { action: "deny" };

--- a/src/main.ts
+++ b/src/main.ts
@@ -895,7 +895,7 @@ function applyWindowPolicy(win: BrowserWindow, allowedOrigin: string): void {
   win.webContents.setWindowOpenHandler(({ url }) => {
     const action = newWindowPolicyAction(url, allowedOrigin);
     if (action === "navigate-in-app") {
-      void win.webContents.loadURL(url);
+      void win.webContents.loadURL(url).catch(() => undefined);
     } else if (action === "open-externally") {
       void shell.openExternal(url);
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -877,7 +877,7 @@ function applyWindowPolicy(win: BrowserWindow, allowedOrigin: string): void {
 
     event.preventDefault();
     if (shouldOpenExternally(targetUrl, allowedOrigin)) {
-      void shell.openExternal(targetUrl);
+      void shell.openExternal(targetUrl).catch(() => undefined);
     }
   });
 
@@ -888,7 +888,7 @@ function applyWindowPolicy(win: BrowserWindow, allowedOrigin: string): void {
 
     event.preventDefault();
     if (shouldOpenExternally(targetUrl, allowedOrigin)) {
-      void shell.openExternal(targetUrl);
+      void shell.openExternal(targetUrl).catch(() => undefined);
     }
   });
 
@@ -897,7 +897,7 @@ function applyWindowPolicy(win: BrowserWindow, allowedOrigin: string): void {
     if (action === "navigate-in-app") {
       void win.webContents.loadURL(url).catch(() => undefined);
     } else if (action === "open-externally") {
-      void shell.openExternal(url);
+      void shell.openExternal(url).catch(() => undefined);
     }
     return { action: "deny" };
   });

--- a/test/window-policy.test.mjs
+++ b/test/window-policy.test.mjs
@@ -5,6 +5,7 @@ import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);
 const {
   isNavigationAllowed,
+  newWindowPolicyAction,
   shouldOpenExternally,
   remotePartitionForProfile,
 } = require("../dist/connection/window-policy.js");
@@ -20,6 +21,36 @@ test("window policy opens external http links outside the allowed origin", () =>
   assert.equal(shouldOpenExternally("https://docs.paperclip.ing", allowedOrigin), true);
   assert.equal(shouldOpenExternally("http://localhost:3100/settings", allowedOrigin), false);
   assert.equal(shouldOpenExternally("mailto:test@example.com", allowedOrigin), false);
+});
+
+test("new-window policy navigates same-origin http links in the app", () => {
+  const allowedOrigin = "http://localhost:3100";
+  assert.equal(
+    newWindowPolicyAction(
+      "http://localhost:3100/agents/agent_123/runs/run_456",
+      allowedOrigin,
+    ),
+    "navigate-in-app",
+  );
+});
+
+test("new-window policy opens different-origin http links externally", () => {
+  const allowedOrigin = "https://paperclip-host.tailnet.ts.net";
+  assert.equal(
+    newWindowPolicyAction("https://docs.paperclip.ing/reference", allowedOrigin),
+    "open-externally",
+  );
+  assert.equal(
+    newWindowPolicyAction("http://example.com", allowedOrigin),
+    "open-externally",
+  );
+});
+
+test("new-window policy denies unsupported and malformed urls", () => {
+  const allowedOrigin = "http://localhost:3100";
+  assert.equal(newWindowPolicyAction("mailto:test@example.com", allowedOrigin), "deny");
+  assert.equal(newWindowPolicyAction("file:///tmp/index.html", allowedOrigin), "deny");
+  assert.equal(newWindowPolicyAction("not a url", allowedOrigin), "deny");
 });
 
 test("remote partitions are isolated per profile", () => {

--- a/test/window-policy.test.mjs
+++ b/test/window-policy.test.mjs
@@ -14,12 +14,17 @@ test("window policy only allows same-origin navigation", () => {
   const allowedOrigin = "https://paperclip-host.tailnet.ts.net";
   assert.equal(isNavigationAllowed("https://paperclip-host.tailnet.ts.net/dashboard", allowedOrigin), true);
   assert.equal(isNavigationAllowed("https://example.com", allowedOrigin), false);
+  assert.equal(
+    isNavigationAllowed("https://user:pass@paperclip-host.tailnet.ts.net/dashboard", allowedOrigin),
+    false,
+  );
 });
 
 test("window policy opens external http links outside the allowed origin", () => {
   const allowedOrigin = "http://localhost:3100";
   assert.equal(shouldOpenExternally("https://docs.paperclip.ing", allowedOrigin), true);
   assert.equal(shouldOpenExternally("http://localhost:3100/settings", allowedOrigin), false);
+  assert.equal(shouldOpenExternally("https://user:pass@docs.paperclip.ing", allowedOrigin), false);
   assert.equal(shouldOpenExternally("mailto:test@example.com", allowedOrigin), false);
 });
 
@@ -48,6 +53,8 @@ test("new-window policy opens different-origin http links externally", () => {
 
 test("new-window policy denies unsupported and malformed urls", () => {
   const allowedOrigin = "http://localhost:3100";
+  assert.equal(newWindowPolicyAction("http://user:pass@localhost:3100/settings", allowedOrigin), "deny");
+  assert.equal(newWindowPolicyAction("https://user:pass@example.com", allowedOrigin), "deny");
   assert.equal(newWindowPolicyAction("mailto:test@example.com", allowedOrigin), "deny");
   assert.equal(newWindowPolicyAction("file:///tmp/index.html", allowedOrigin), "deny");
   assert.equal(newWindowPolicyAction("not a url", allowedOrigin), "deny");


### PR DESCRIPTION
## Summary
- classify Electron new-window requests so same-origin Paperclip routes are navigated in the existing app window
- keep different-origin HTTP(S) links opening in the default browser
- deny unsupported, malformed, and credential-bearing window-policy URLs
- catch failed in-app popup navigation and external browser handoff promises to avoid unhandled rejections from renderer-controlled URLs

Closes #22.

## Tests and scans
- `pnpm build && node --test test/window-policy.test.mjs`
- `pnpm test:connections`
- `pnpm audit --prod`
- `pnpm audit --dev`